### PR TITLE
Port celt module key types to Rust

### DIFF
--- a/src/celt/mod.rs
+++ b/src/celt/mod.rs
@@ -1,0 +1,11 @@
+//! CELT module internals.
+//!
+//! This module contains foundational types for the Rust port of the CELT
+//! implementation.  The definitions are intentionally close to the original C
+//! structures so that subsequent ports can translate field-by-field logic while
+//! relying on Rust's ownership and lifetime tracking for safety.
+
+mod types;
+
+#[allow(unused_imports)]
+pub(crate) use types::*;

--- a/src/celt/types.rs
+++ b/src/celt/types.rs
@@ -1,0 +1,352 @@
+#![allow(dead_code)]
+
+/// Corresponds to `opus_int32` in the C implementation.
+pub type OpusInt32 = i32;
+/// Corresponds to `opus_uint32` in the C implementation.
+pub type OpusUint32 = u32;
+/// Floating-point representation used for `opus_val16` in CELT's float build.
+pub type OpusVal16 = f32;
+/// Floating-point representation used for `opus_val32` in CELT's float build.
+pub type OpusVal32 = f32;
+/// Internal CELT signal precision.
+pub type CeltSig = OpusVal32;
+/// Internal CELT logarithmic energy precision.
+pub type CeltGlog = OpusVal32;
+/// Coefficients used by the MDCT windows.
+pub type CeltCoef = OpusVal16;
+
+/// Placeholder for the KISS FFT state referenced by the MDCT lookup tables.
+#[derive(Debug, Clone, Default)]
+pub struct KissFftState;
+
+/// Scalar type used by the KISS FFT tables.
+pub type KissTwiddleScalar = f32;
+
+/// Lookup table required by CELT's MDCT implementation.
+///
+/// Mirrors the layout of `mdct_lookup` from `celt/mdct.h` while relying on Rust
+/// slices to express borrowed data. The lookup owns no memory itself; the
+/// lifetimes keep the dependency graph explicit without resorting to raw
+/// pointers.
+#[derive(Debug, Clone)]
+pub struct MdctLookup<'a> {
+    pub len: usize,
+    pub max_shift: usize,
+    pub fft: [Option<&'a KissFftState>; 4],
+    pub twiddle: &'a [KissTwiddleScalar],
+}
+
+impl<'a> MdctLookup<'a> {
+    pub fn new(len: usize, max_shift: usize, twiddle: &'a [KissTwiddleScalar]) -> Self {
+        Self {
+            len,
+            max_shift,
+            fft: [None; 4],
+            twiddle,
+        }
+    }
+}
+
+/// Pulse cache information embedded inside `OpusCustomMode`.
+#[derive(Debug, Clone)]
+pub struct PulseCache<'a> {
+    pub size: usize,
+    pub index: &'a [i16],
+    pub bits: &'a [u8],
+    pub caps: &'a [u8],
+}
+
+/// Rust port of the opaque `OpusCustomMode`/`CELTMode` type.
+#[derive(Debug, Clone)]
+pub struct OpusCustomMode<'a> {
+    pub sample_rate: OpusInt32,
+    pub overlap: usize,
+    pub num_ebands: usize,
+    pub effective_ebands: usize,
+    pub pre_emphasis: [OpusVal16; 4],
+    pub e_bands: &'a [i16],
+    pub max_lm: usize,
+    pub num_short_mdcts: usize,
+    pub short_mdct_size: usize,
+    pub num_alloc_vectors: usize,
+    pub alloc_vectors: &'a [u8],
+    pub log_n: &'a [i16],
+    pub window: &'a [CeltCoef],
+    pub mdct: MdctLookup<'a>,
+    pub cache: PulseCache<'a>,
+}
+
+impl<'a> OpusCustomMode<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        sample_rate: OpusInt32,
+        overlap: usize,
+        e_bands: &'a [i16],
+        alloc_vectors: &'a [u8],
+        log_n: &'a [i16],
+        window: &'a [CeltCoef],
+        mdct: MdctLookup<'a>,
+        cache: PulseCache<'a>,
+    ) -> Self {
+        Self {
+            sample_rate,
+            overlap,
+            num_ebands: e_bands.len(),
+            effective_ebands: e_bands.len(),
+            pre_emphasis: [0.0; 4],
+            e_bands,
+            max_lm: 0,
+            num_short_mdcts: 0,
+            short_mdct_size: 0,
+            num_alloc_vectors: alloc_vectors.len(),
+            alloc_vectors,
+            log_n,
+            window,
+            mdct,
+            cache,
+        }
+    }
+}
+
+/// CELT analysis metadata shared between SILK and CELT.
+#[derive(Debug, Clone, Default)]
+pub struct AnalysisInfo {
+    pub valid: bool,
+    pub tonality: f32,
+    pub tonality_slope: f32,
+    pub noisiness: f32,
+    pub activity: f32,
+    pub music_prob: f32,
+    pub music_prob_min: f32,
+    pub music_prob_max: f32,
+    pub bandwidth: i32,
+    pub activity_probability: f32,
+    pub max_pitch_ratio: f32,
+    pub leak_boost: [u8; 19],
+}
+
+/// Minimal port of the auxiliary SILK information embedded in the encoder.
+#[derive(Debug, Clone, Default)]
+pub struct SilkInfo {
+    pub signal_type: i32,
+    pub offset: i32,
+}
+
+/// Primary encoder state for CELT.
+#[derive(Debug)]
+pub struct OpusCustomEncoder<'a> {
+    pub mode: &'a OpusCustomMode<'a>,
+    pub channels: usize,
+    pub stream_channels: usize,
+    pub force_intra: bool,
+    pub clip: bool,
+    pub disable_prefilter: bool,
+    pub complexity: i32,
+    pub upsample: i32,
+    pub start_band: i32,
+    pub end_band: i32,
+    pub bitrate: OpusInt32,
+    pub use_vbr: bool,
+    pub signalling: i32,
+    pub constrained_vbr: bool,
+    pub loss_rate: i32,
+    pub lsb_depth: i32,
+    pub lfe: bool,
+    pub disable_inv: bool,
+    pub arch: i32,
+    pub rng: OpusUint32,
+    pub spread_decision: i32,
+    pub delayed_intra: OpusVal32,
+    pub tonal_average: i32,
+    pub last_coded_bands: i32,
+    pub hf_average: i32,
+    pub tapset_decision: i32,
+    pub prefilter_period: i32,
+    pub prefilter_gain: OpusVal16,
+    pub prefilter_tapset: i32,
+    pub consec_transient: i32,
+    pub analysis: AnalysisInfo,
+    pub silk_info: SilkInfo,
+    pub preemph_mem_encoder: [OpusVal32; 2],
+    pub preemph_mem_decoder: [OpusVal32; 2],
+    pub vbr_reservoir: OpusInt32,
+    pub vbr_drift: OpusInt32,
+    pub vbr_offset: OpusInt32,
+    pub vbr_count: OpusInt32,
+    pub overlap_max: OpusVal32,
+    pub stereo_saving: OpusVal16,
+    pub intensity: i32,
+    pub energy_mask: Option<&'a [CeltGlog]>,
+    pub spec_avg: CeltGlog,
+    pub in_mem: &'a mut [CeltSig],
+    pub prefilter_mem: &'a mut [CeltSig],
+    pub old_band_e: &'a mut [CeltGlog],
+    pub old_log_e: &'a mut [CeltGlog],
+    pub old_log_e2: &'a mut [CeltGlog],
+    pub energy_error: &'a mut [CeltGlog],
+}
+
+impl<'a> OpusCustomEncoder<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        mode: &'a OpusCustomMode<'a>,
+        channels: usize,
+        stream_channels: usize,
+        energy_mask: Option<&'a [CeltGlog]>,
+        in_mem: &'a mut [CeltSig],
+        prefilter_mem: &'a mut [CeltSig],
+        old_band_e: &'a mut [CeltGlog],
+        old_log_e: &'a mut [CeltGlog],
+        old_log_e2: &'a mut [CeltGlog],
+        energy_error: &'a mut [CeltGlog],
+    ) -> Self {
+        let overlap = mode.overlap * channels;
+        debug_assert_eq!(in_mem.len(), overlap);
+        let band_count = channels * mode.num_ebands;
+        debug_assert_eq!(old_band_e.len(), band_count);
+        debug_assert_eq!(old_log_e.len(), band_count);
+        debug_assert_eq!(old_log_e2.len(), band_count);
+        debug_assert_eq!(energy_error.len(), band_count);
+        Self {
+            mode,
+            channels,
+            stream_channels,
+            force_intra: false,
+            clip: false,
+            disable_prefilter: false,
+            complexity: 0,
+            upsample: 1,
+            start_band: 0,
+            end_band: mode.num_ebands as i32,
+            bitrate: 0,
+            use_vbr: false,
+            signalling: 0,
+            constrained_vbr: false,
+            loss_rate: 0,
+            lsb_depth: 0,
+            lfe: false,
+            disable_inv: false,
+            arch: 0,
+            rng: 0,
+            spread_decision: 0,
+            delayed_intra: 0.0,
+            tonal_average: 0,
+            last_coded_bands: 0,
+            hf_average: 0,
+            tapset_decision: 0,
+            prefilter_period: 0,
+            prefilter_gain: 0.0,
+            prefilter_tapset: 0,
+            consec_transient: 0,
+            analysis: AnalysisInfo::default(),
+            silk_info: SilkInfo::default(),
+            preemph_mem_encoder: [0.0; 2],
+            preemph_mem_decoder: [0.0; 2],
+            vbr_reservoir: 0,
+            vbr_drift: 0,
+            vbr_offset: 0,
+            vbr_count: 0,
+            overlap_max: 0.0,
+            stereo_saving: 0.0,
+            intensity: 0,
+            energy_mask,
+            spec_avg: 0.0,
+            in_mem,
+            prefilter_mem,
+            old_band_e,
+            old_log_e,
+            old_log_e2,
+            energy_error,
+        }
+    }
+}
+
+/// Primary decoder state for CELT.
+#[derive(Debug)]
+pub struct OpusCustomDecoder<'a> {
+    pub mode: &'a OpusCustomMode<'a>,
+    pub overlap: usize,
+    pub channels: usize,
+    pub stream_channels: usize,
+    pub downsample: i32,
+    pub start_band: i32,
+    pub end_band: i32,
+    pub signalling: i32,
+    pub disable_inv: bool,
+    pub complexity: i32,
+    pub arch: i32,
+    pub rng: OpusUint32,
+    pub error: i32,
+    pub last_pitch_index: i32,
+    pub loss_duration: i32,
+    pub skip_plc: bool,
+    pub postfilter_period: i32,
+    pub postfilter_period_old: i32,
+    pub postfilter_gain: OpusVal16,
+    pub postfilter_gain_old: OpusVal16,
+    pub postfilter_tapset: i32,
+    pub postfilter_tapset_old: i32,
+    pub prefilter_and_fold: bool,
+    pub preemph_mem_decoder: [CeltSig; 2],
+    pub decode_mem: &'a mut [CeltSig],
+    pub lpc: &'a mut [OpusVal16],
+    pub old_ebands: &'a mut [CeltGlog],
+    pub old_log_e: &'a mut [CeltGlog],
+    pub old_log_e2: &'a mut [CeltGlog],
+    pub background_log_e: &'a mut [CeltGlog],
+}
+
+impl<'a> OpusCustomDecoder<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        mode: &'a OpusCustomMode<'a>,
+        channels: usize,
+        stream_channels: usize,
+        decode_mem: &'a mut [CeltSig],
+        lpc: &'a mut [OpusVal16],
+        old_ebands: &'a mut [CeltGlog],
+        old_log_e: &'a mut [CeltGlog],
+        old_log_e2: &'a mut [CeltGlog],
+        background_log_e: &'a mut [CeltGlog],
+    ) -> Self {
+        let overlap = mode.overlap * channels;
+        debug_assert!(decode_mem.len() >= overlap);
+        let band_count = 2 * mode.num_ebands;
+        debug_assert_eq!(old_ebands.len(), band_count);
+        debug_assert_eq!(old_log_e.len(), band_count);
+        debug_assert_eq!(old_log_e2.len(), band_count);
+        debug_assert_eq!(background_log_e.len(), band_count);
+        Self {
+            mode,
+            overlap,
+            channels,
+            stream_channels,
+            downsample: 1,
+            start_band: 0,
+            end_band: mode.num_ebands as i32,
+            signalling: 0,
+            disable_inv: false,
+            complexity: 0,
+            arch: 0,
+            rng: 0,
+            error: 0,
+            last_pitch_index: 0,
+            loss_duration: 0,
+            skip_plc: false,
+            postfilter_period: 0,
+            postfilter_period_old: 0,
+            postfilter_gain: 0.0,
+            postfilter_gain_old: 0.0,
+            postfilter_tapset: 0,
+            postfilter_tapset_old: 0,
+            prefilter_and_fold: false,
+            preemph_mem_decoder: [0.0; 2],
+            decode_mem,
+            lpc,
+            old_ebands,
+            old_log_e,
+            old_log_e2,
+            background_log_e,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
+extern crate alloc;
+
 pub mod bitdepth;
+mod celt;
 pub mod decoder;
 mod math;
 pub mod oggreader;


### PR DESCRIPTION
## Summary
- replace dynamic Vec/Cow fields in CELT lookup and state structs with stack-based arrays or borrowed slices
- require callers to supply pre-allocated encoder and decoder buffers that mirror the original CELT layout and validate their dimensions

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_b_68dc1bb918b0832a84bbe4c834c12113