### PR TITLE
Fix fast_atan2f CB constant to match C float precision

### DIFF
--- a/src/celt/math.rs
+++ b/src/celt/math.rs
@@ -48,9 +48,10 @@ pub(crate) fn isqrt32(mut value: u32) -> u32 {
 /// heuristics that rely on it while avoiding the cost of calling into libm.
 #[allow(clippy::many_single_char_names)]
 pub(crate) fn fast_atan2f(y: f32, x: f32) -> f32 {
-    const CA: f32 = 0.431_579_74;
-    const CB: f32 = 0.678_484_03;
-    const CC: f32 = 0.085_955_42;
+    const CA: f32 = 0.431_579_74_f32;
+    // Matches the 0.67848403f literal used in `celt/mathops.h` in the C tree.
+    const CB: f32 = f32::from_bits(0x3f2d_b121);
+    const CC: f32 = 0.085_955_42_f32;
     const CE: f32 = PI / 2.0;
 
     let x2 = x * x;


### PR DESCRIPTION
## Summary
- ensure the fast_atan2f polynomial constants are typed as f32 values
- load the CB coefficient from its exact f32 bit pattern to match the C literal and silence clippy's precision warning

## Testing
- cargo check
- cargo test
- cargo clippy --all-targets

------
https://chatgpt.com/codex/tasks/task_b_68dccfcee85c832abe8742178921640f