### PR TITLE
Remove redundant os_support helpers

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -86,3 +86,12 @@ support headers.
 Additional directories (`arm/`, `mips/`, `x86/`) contain architecture-specific
 optimisations that depend on the scalar implementations above and remain to be
 ported once the scalar logic is in place.
+
+## Modules intentionally left unported
+
+### `os_support.h`
+- The C helpers in `celt/os_support.h` wrap manual heap management and raw
+  memory utilities. Rust's standard library already provides safe and idiomatic
+  equivalents (`Vec`, RAII-managed drops, and slice copying/clearing
+  primitives), so introducing a dedicated wrapper module would only duplicate
+  existing functionality without aiding the porting effort.


### PR DESCRIPTION
## Summary
- drop the temporary `os_support` module from the CELT port
- clarify in the porting status document that the C helpers are unnecessary in Rust

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68dcd1a95cd4832aa4d886b9f8949fa8