### PR TITLE
Port cwrs log2_frac helper

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -65,6 +65,10 @@ safely.
   `celt/entenc.c`, including carry propagation, binary/ICDF symbol coding,
   unsigned integer support, raw bit packing, and buffer finalisation.
 
+### `cwrs.rs`
+- `log2_frac` &rarr; ports the conservative fractional logarithm estimator used
+  by the pulse codeword enumerator in `celt/cwrs.c`.
+
 ## Remaining C modules and their dependencies
 
 The table below lists the major `.c` files under `celt/` in the reference tree
@@ -79,7 +83,7 @@ support headers.
 | `celt_decoder.c` | Decoder main loop, PLC, postfilter. | `mdct`, `pitch`, `bands`, `modes`, `entcode`, `quant_bands`, `rate`, `mathops`, `celt_lpc`, `vq`, `lpcnet` |
 | `celt_encoder.c` | Encoder analysis, bit allocation, transient detection. | `mdct`, `pitch`, `bands`, `modes`, `entcode`, `quant_bands`, `rate`, `mathops`, `celt_lpc`, `vq` |
 | `celt_lpc.c` | LPC analysis helpers (short-term prediction). | `celt_lpc`, `mathops`, `pitch` |
-| `cwrs.c` | Combinatorial pulse encoding/decoding. | `cwrs`, `mathops` |
+| `cwrs.c` | Combinatorial pulse encoding/decoding (excluding `log2_frac`, now ported). | `cwrs`, `mathops` |
 | `entcode.c` | Range encoder utilities shared by `entenc`/`entdec`. | `entcode` |
 | `kiss_fft.c` | KISS FFT backend used by the MDCT. | `kiss_fft`, `mathops`, `stack_alloc` |
 | `mathops.c` | Fixed- and float-point math helpers beyond the ones already ported. | `mathops`, `float_cast` |

--- a/src/celt/cwrs.rs
+++ b/src/celt/cwrs.rs
@@ -1,0 +1,102 @@
+#![allow(dead_code)]
+
+//! Pulse vector combinatorics helpers from the reference CELT implementation.
+//!
+//! The routines in this module have minimal dependencies on the rest of the
+//! encoder/decoder pipeline and can therefore be ported in isolation.  They
+//! primarily operate on integer combinatorics used by the codeword
+//! enumeration logic in `cwrs.c`.
+
+use crate::celt::entcode::ec_ilog;
+use crate::celt::types::{OpusInt32, OpusUint32};
+
+/// Returns a conservatively large estimate of `log2(val)` with `frac` fractional bits.
+///
+/// Mirrors `log2_frac()` from `celt/cwrs.c`. The routine assumes `val > 0` and that
+/// `frac` is non-negative. The result is guaranteed to be greater than or equal to
+/// the exact value, matching the behaviour of the C implementation which the
+/// bit-allocation heuristics rely on for safety margins.
+#[must_use]
+pub(crate) fn log2_frac(mut val: OpusUint32, frac: OpusInt32) -> OpusInt32 {
+    debug_assert!(val > 0);
+    debug_assert!(frac >= 0);
+
+    let l = ec_ilog(val);
+    if val & (val - 1) != 0 {
+        if l > 16 {
+            val = ((val - 1) >> ((l - 16) as u32)) + 1;
+        } else {
+            val <<= (16 - l) as u32;
+        }
+
+        let mut acc = (l - 1) << frac;
+        let mut current_frac = frac;
+
+        loop {
+            let b = (val >> 16) as OpusInt32;
+            let shift = current_frac as u32;
+            debug_assert!(current_frac <= 30);
+            acc += b << shift;
+            val = (val + b as OpusUint32) >> (b as u32);
+            val = ((val * val) + 0x7FFF) >> 15;
+
+            if current_frac <= 0 {
+                break;
+            }
+            current_frac -= 1;
+        }
+
+        acc + OpusInt32::from(val > 0x8000)
+    } else {
+        (l - 1) << frac
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::log2_frac;
+
+    fn reference_log2_frac(val: u32, frac: i32) -> i32 {
+        let scale = 1 << frac;
+        ((val as f64).log2() * f64::from(scale)).ceil() as i32
+    }
+
+    #[test]
+    fn matches_reference_estimate_for_small_values() {
+        for val in 1..=256u32 {
+            for frac in 0..=6 {
+                let exact = reference_log2_frac(val, frac);
+                let estimate = log2_frac(val, frac);
+                assert!(
+                    estimate >= exact,
+                    "estimate {} < exact {} for val={}, frac={}",
+                    estimate,
+                    exact,
+                    val,
+                    frac
+                );
+                assert!(
+                    estimate - exact <= 1,
+                    "estimate {} too far from exact {} for val={}, frac={}",
+                    estimate,
+                    exact,
+                    val,
+                    frac
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn matches_reference_estimate_for_large_values() {
+        let samples = [0x0001_FFEE, 0x00FF_FFFF, 0x0F00_0001, 0x8000_0000, 0xFFFF_FFFE];
+        for &val in &samples {
+            for frac in 0..=6 {
+                let exact = reference_log2_frac(val, frac);
+                let estimate = log2_frac(val, frac);
+                assert!(estimate >= exact);
+                assert!(estimate - exact <= 2);
+            }
+        }
+    }
+}

--- a/src/celt/mod.rs
+++ b/src/celt/mod.rs
@@ -8,11 +8,14 @@
 mod entcode;
 mod entdec;
 mod entenc;
+mod cwrs;
 mod laplace;
 mod math;
 mod types;
 mod vq;
 
+#[allow(unused_imports)]
+pub(crate) use cwrs::*;
 #[allow(unused_imports)]
 pub(crate) use entcode::*;
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary
- add a cwrs module that ports the `log2_frac` helper from the C reference
- re-export the new helper from the CELT module tree and document its status

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68dcdcb2e600832abb94e09d9e0b0a08