### PR TITLE
Port CELT float-to-int16 helper

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -15,6 +15,8 @@ safely.
 - `isqrt32` &rarr; integer square root routine from `celt/mathops.c`.
 - `opus_limit2_checkwithin1` &rarr; scalar sample clamp helper from
   `celt/mathops.c`.
+- `celt_float2int16` &rarr; float-to-int16 conversion helper from
+  `celt/mathops.c`.
 
 ### `types.rs`
 - Scalar aliases `OpusInt32`, `OpusUint32`, `OpusVal16`, `OpusVal32`,


### PR DESCRIPTION
## Summary
- port the `celt_float2int16` conversion helper from `celt/mathops.c`
- add unit tests covering saturation, rounding, and length checks
- document the ported helper in `PORTING_STATUS.md`

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68dcdfa4ceb4832abc3004b69cf4bd87