### PR TITLE
Port pitch cross-correlation helper

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -96,6 +96,9 @@ safely.
   `dual_inner_prod_c()` in `celt/pitch.c`.
 - `compute_pitch_gain` &rarr; float pitch gain normalisation matching the
   `compute_pitch_gain()` utility in `celt/pitch.c`.
+- `celt_pitch_xcorr` &rarr; scalar pitch cross-correlation routine from
+  `celt/pitch.c` that evaluates delayed inner products between the excitation and
+  target windows.
 
 ## Remaining C modules and their dependencies
 


### PR DESCRIPTION
## Summary
- port the scalar celt_pitch_xcorr helper from celt/pitch.c into the Rust pitch module
- add a unit test that checks the cross-correlation output against a naive implementation
- document the new coverage in the CELT porting status overview

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68dcface9ee4832aa2ab59cac17f8afd