### PR TITLE
Port bitexact band helpers

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -13,6 +13,9 @@ safely.
   thresholds.
 - `celt_lcg_rand` &rarr; mirrors the linear congruential pseudo-random number
   generator used by the band analysis heuristics in `celt/bands.c`.
+- `bitexact_cos` and `bitexact_log2tan` &rarr; translate the bit-exact cosine
+  and logarithmic tangent approximations used by the stereo analysis tools in
+  `celt/bands.c`.
 
 ### `math.rs`
 - `fast_atan2f` &rarr; mirrors the helper of the same name in


### PR DESCRIPTION
## Summary
- port the bitexact cosine and log2tan helpers from `celt/bands.c`, including the shared fractional multiply helper
- add unit tests that compare the helpers against reference outputs to ensure the fixed-point behaviour matches C
- update the CELT porting status document to record the newly ported functions

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68dd23acbf70832aa6acc4af80a0dc4c