### PR TITLE
Port compute_channel_weights from bands.c

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -16,6 +16,9 @@ safely.
 - `bitexact_cos` and `bitexact_log2tan` &rarr; translate the bit-exact cosine
   and logarithmic tangent approximations used by the stereo analysis tools in
   `celt/bands.c`.
+- `compute_channel_weights` &rarr; ports the stereo weighting helper from
+  `celt/bands.c` that balances distortion across channels using adjusted
+  energy estimates.
 
 ### `math.rs`
 - `fast_atan2f` &rarr; mirrors the helper of the same name in


### PR DESCRIPTION
## Summary
- port the `compute_channel_weights` helper from `celt/bands.c`
- cover the weighting behaviour with unit tests
- update `PORTING_STATUS.md` to reflect the newly ported helper

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68dd2b208144832a8a5dd780ac2d8c20