### PR TITLE
Port stereo_split helper from bands.c

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -19,6 +19,9 @@ safely.
 - `compute_channel_weights` &rarr; ports the stereo weighting helper from
   `celt/bands.c` that balances distortion across channels using adjusted
   energy estimates.
+- `stereo_split` &rarr; ports the mid/side-to-left/right transform from
+  `celt/bands.c`, applying the orthonormal scaling used when decoding stereo
+  bands.
 
 ### `math.rs`
 - `fast_atan2f` &rarr; mirrors the helper of the same name in


### PR DESCRIPTION
## Summary
- port the `stereo_split` mid/side transform from `celt/bands.c` into the Rust bands module
- add targeted unit coverage that checks the transform against the reference formula
- document the new helper in the CELT porting status tracker

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68dd308eee70832aaa16fac729206cdb