### PR TITLE
Port stereo_merge helper from CELT bands module

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -27,6 +27,9 @@ safely.
 - `stereo_split` &rarr; ports the mid/side-to-left/right transform from
   `celt/bands.c`, applying the orthonormal scaling used when decoding stereo
   bands.
+- `stereo_merge` &rarr; mirrors the float mid/side reconstruction helper from
+  `celt/bands.c`, including the energy guards and normalisation gains used when
+  converting encoded mid/side pairs back to left/right channels.
 
 ### `math.rs`
 - `fast_atan2f` &rarr; mirrors the helper of the same name in


### PR DESCRIPTION
## Summary
- port the float configuration of stereo_merge from celt/bands.c into the Rust bands module
- add unit tests that compare the Rust port against a direct reference implementation and cover the low-energy guard path
- document the new coverage in src/celt/PORTING_STATUS.md

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68dd3b0a7204832ab8bcec771ed93e8a