### PR TITLE
Port compute_pulse_cache and update pulse cache storage

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -149,6 +149,8 @@ safely.
 - `fits_in32` &rarr; ports the custom-modes guard from `celt/rate.c` that checks
   whether `V(N, K)` fits inside an unsigned 32-bit integer when building the
   pulse cache.
+- `compute_pulse_cache` &rarr; recreates the PVQ cache generation routine from
+  `celt/rate.c`, including the per-band bit caps used by custom modes.
 
 ### `quant_bands.rs`
 - `loss_distortion` &rarr; ports the distortion metric helper from
@@ -187,7 +189,7 @@ support headers.
 | `modes.c` | Mode construction, static tables, precomputed caches. | `celt`, `modes`, `rate`, `quant_bands` |
 | `pitch.c` | Pitch correlation/search and postfilter helpers. | `modes`, `mathops`, `celt_lpc` |
 | `quant_bands.c` | Band quantisation tables and rate allocation. | `quant_bands`, `laplace`, `mathops`, `rate` |
-| `rate.c` | Bitrate distribution and pulse cache logic (excluding the helper constants and guards now in `rate.rs`). | `modes`, `cwrs`, `entcode`, `rate` |
+| `rate.c` | Remaining bitrate distribution heuristics (the helper constants and pulse cache builder now live in Rust). | `modes`, `cwrs`, `entcode`, `rate` |
 | `vq.c` (remaining parts) | Pulse allocation, PVQ search, and quantiser core. | `mathops`, `cwrs`, `bands`, `rate`, `pitch` |
 
 Additional directories (`arm/`, `mips/`, `x86/`) contain architecture-specific

--- a/src/celt/bands.rs
+++ b/src/celt/bands.rs
@@ -296,7 +296,7 @@ mod tests {
         compute_channel_weights, frac_mul16, hysteresis_decision, normalise_bands, stereo_merge,
         stereo_split,
     };
-    use crate::celt::types::{CeltSig, MdctLookup, OpusCustomMode, PulseCache};
+    use crate::celt::types::{CeltSig, MdctLookup, OpusCustomMode, PulseCacheData};
     use crate::celt::{celt_rsqrt_norm, dual_inner_prod};
     use alloc::vec;
     use alloc::vec::Vec;
@@ -534,12 +534,7 @@ mod tests {
             log_n: &[],
             window: &[],
             mdct,
-            cache: PulseCache {
-                size: 0,
-                index: &[],
-                bits: &[],
-                caps: &[],
-            },
+            cache: PulseCacheData::default(),
         }
     }
 

--- a/src/celt/rate.rs
+++ b/src/celt/rate.rs
@@ -7,6 +7,14 @@
 
 #![allow(dead_code)]
 
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
+
+use crate::celt::cwrs::get_required_bits;
+use crate::celt::entcode::BITRES;
+use crate::celt::types::{OpusInt16, OpusInt32, PulseCacheData};
+
 /// Maximum pseudo-pulse index described in the C headers.
 pub(crate) const MAX_PSEUDO: i32 = 40;
 /// Base-2 logarithm of [`MAX_PSEUDO`] used by the search helpers.
@@ -60,9 +68,167 @@ pub(crate) fn fits_in32(n: i32, k: i32) -> bool {
     }
 }
 
+/// Recomputes the pulse cache used by custom modes.
+///
+/// Mirrors `compute_pulse_cache()` from `celt/rate.c`, porting the allocation of
+/// the PVQ lookup tables and the per-band bit caps to safe Rust containers. The
+/// helper is written to match the original control flow closely so that the
+/// results can be compared against the C reference when validating future
+/// translations.
+#[allow(clippy::too_many_lines)]
+pub(crate) fn compute_pulse_cache(
+    e_bands: &[OpusInt16],
+    log_n: &[OpusInt16],
+    lm: usize,
+) -> PulseCacheData {
+    let nb_ebands = e_bands.len().saturating_sub(1);
+    let rows = nb_ebands * (lm + 2);
+    let mut index = vec![-1i32; rows];
+    let mut entry_n = Vec::new();
+    let mut entry_k = Vec::new();
+    let mut entry_offset = Vec::new();
+    let mut curr = 0i32;
+
+    for i in 0..=(lm + 1) {
+        for j in 0..nb_ebands {
+            let mut n = i32::from(e_bands[j + 1] - e_bands[j]);
+            n = (n << i) >> 1;
+            let row = i * nb_ebands + j;
+            index[row] = -1;
+
+            for k in 0..=i {
+                for n_idx in 0..nb_ebands {
+                    if k == i && n_idx >= j {
+                        break;
+                    }
+                    let mut other = i32::from(e_bands[n_idx + 1] - e_bands[n_idx]);
+                    other = (other << k) >> 1;
+                    if n == other {
+                        index[row] = index[k * nb_ebands + n_idx];
+                        break;
+                    }
+                }
+                if index[row] != -1 {
+                    break;
+                }
+            }
+
+            if index[row] == -1 && n != 0 {
+                let mut k = 0;
+                while k < MAX_PSEUDO && fits_in32(n, get_pulses(k + 1)) {
+                    k += 1;
+                }
+                entry_n.push(n);
+                entry_k.push(k);
+                entry_offset.push(curr);
+                index[row] = curr;
+                curr += k + 1;
+            }
+        }
+    }
+
+    let mut bits = vec![0u8; curr.max(0) as usize];
+    for idx in 0..entry_n.len() {
+        let n = entry_n[idx] as usize;
+        let k = entry_k[idx] as usize;
+        let offset = entry_offset[idx] as usize;
+        let mut scratch = vec![0 as OpusInt16; CELT_MAX_PULSES + 1];
+        let max_k = get_pulses(entry_k[idx]) as usize;
+        get_required_bits(&mut scratch, n, max_k, BITRES as OpusInt32);
+
+        bits[offset] = k as u8;
+        for j in 1..=k {
+            let pulses = get_pulses(j as i32) as usize;
+            let value = scratch[pulses] - 1;
+            debug_assert!((0..=u8::MAX as OpusInt16).contains(&value));
+            bits[offset + j] = value as u8;
+        }
+    }
+
+    let mut caps = vec![0u8; (lm + 1) * 2 * nb_ebands];
+    let shift = BITRES as usize;
+    for i in 0..=lm {
+        for c in 1..=2 {
+            let c_i32 = c as i32;
+            for j in 0..nb_ebands {
+                let mut n0 = i32::from(e_bands[j + 1] - e_bands[j]);
+                let max_bits = if (n0 << i) == 1 {
+                    (c_i32 * (1 + MAX_FINE_BITS)) << shift
+                } else {
+                    let mut lm0 = 0i32;
+                    if n0 > 2 {
+                        n0 >>= 1;
+                        lm0 -= 1;
+                    } else if n0 <= 1 {
+                        lm0 = i32::min(i as i32, 1);
+                        n0 <<= lm0 as usize;
+                    }
+
+                    let row = ((lm0 + 1) as usize) * nb_ebands + j;
+                    let cache_offset = index[row];
+                    debug_assert!(cache_offset >= 0, "pulse cache entry should exist");
+                    let cache_offset = cache_offset as usize;
+                    let entry_k = bits[cache_offset] as i32;
+                    let base_idx = cache_offset + entry_k as usize;
+                    let mut local_bits = i32::from(bits[base_idx]) + 1;
+                    let iterations = (i as i32 - lm0).max(0);
+                    let mut n = n0;
+                    for k_iter in 0..iterations {
+                        local_bits <<= 1;
+                        let offset = ((i32::from(log_n[j]) + ((lm0 + k_iter) << shift)) >> 1)
+                            - QTHETA_OFFSET;
+                        let two_n_minus_one = 2 * n - 1;
+                        let num = 459 * (two_n_minus_one * offset + local_bits);
+                        let den = (two_n_minus_one << 9) - 459;
+                        let mut qb = ((num + (den >> 1)) / den).min(57);
+                        debug_assert!(qb >= 0);
+                        if qb < 0 {
+                            qb = 0;
+                        }
+                        local_bits += qb;
+                        let offset_guard = offset.max(0);
+                        local_bits = local_bits.max(c_i32 * (offset_guard + (4 << shift)));
+                        n <<= 1;
+                    }
+
+                    let ndof = (c_i32 * n0 - (c_i32 - 1)).max(1);
+                    local_bits = local_bits.min(c_i32 * n0 << shift);
+                    let pulses = get_pulses(entry_k) + 2 * (ndof - 1);
+                    let floor = c_i32 * ((pulses / (2 * ndof)) << shift);
+                    local_bits = local_bits.max(floor);
+                    if (n0 << i) == 2 {
+                        let extra = ((c_i32 * (1 + 16)) >> 1) << shift;
+                        local_bits = local_bits.max(extra);
+                    }
+                    if c == 2 && (n0 << i) >= 2 {
+                        let extra = ((2 * (1 + 24)) >> 1) << shift;
+                        local_bits = local_bits.max(extra);
+                    }
+
+                    local_bits
+                };
+
+                let cap_idx = i * 2 * nb_ebands + (c - 1) * nb_ebands + j;
+                if !caps.is_empty() {
+                    caps[cap_idx] = ((max_bits >> shift).min(255)) as u8;
+                }
+            }
+        }
+    }
+
+    let index = index
+        .into_iter()
+        .map(|value| i16::try_from(value).expect("pulse cache index exceeds 16-bit range"))
+        .collect();
+
+    PulseCacheData::new(index, bits, caps)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{fits_in32, get_pulses};
+    use alloc::collections::BTreeMap;
+
+    use super::{compute_pulse_cache, fits_in32, get_pulses};
 
     #[test]
     fn get_pulses_matches_reference_pattern() {
@@ -95,5 +261,38 @@ mod tests {
 
         // Large values that violate the final MAX_N entry should fail.
         assert!(!fits_in32(15, 13));
+    }
+
+    #[test]
+    fn compute_pulse_cache_assigns_shared_offsets() {
+        let e_bands = [0i16, 2, 6];
+        let log_n = [6i16, 7];
+        let lm = 1usize;
+        let cache = compute_pulse_cache(&e_bands, &log_n, lm);
+
+        let nb_ebands = e_bands.len() - 1;
+        assert_eq!(cache.size, cache.bits.len());
+        assert_eq!(cache.index.len(), nb_ebands * (lm + 2));
+        assert_eq!(cache.caps.len(), (lm + 1) * 2 * nb_ebands);
+
+        let mut seen = BTreeMap::new();
+        for i in 0..=(lm + 1) {
+            for j in 0..nb_ebands {
+                let n = i32::from(e_bands[j + 1] - e_bands[j]);
+                let n = (n << i) >> 1;
+                if n == 0 {
+                    continue;
+                }
+                let offset = cache.index[i * nb_ebands + j];
+                if let Some(&expected) = seen.get(&n) {
+                    assert_eq!(offset, expected);
+                } else {
+                    seen.insert(n, offset);
+                    let offset = offset as usize;
+                    let k = cache.bits[offset] as usize;
+                    assert!(offset + k < cache.bits.len());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add an owned `PulseCacheData` container and expose a borrowed view from `OpusCustomMode`
- port `compute_pulse_cache` from `celt/rate.c` and add a unit test that exercises cache reuse
- update CELT porting status and adjust test helpers to use the new cache representation

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68dd42c8466c832a91714fef600d0b73