### PR TITLE
Align entcode port with reference implementation

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -182,7 +182,6 @@ support headers.
 | `celt.c` | Top-level encoder/decoder glue (frame dispatch, overlap-add). | `mdct`, `pitch`, `bands`, `modes`, `entcode`, `quant_bands`, `rate`, `mathops`, `celt_lpc`, `vq` |
 | `celt_decoder.c` | Decoder main loop, PLC, postfilter. | `mdct`, `pitch`, `bands`, `modes`, `entcode`, `quant_bands`, `rate`, `mathops`, `celt_lpc`, `vq`, `lpcnet` |
 | `celt_encoder.c` | Encoder analysis, bit allocation, transient detection. | `mdct`, `pitch`, `bands`, `modes`, `entcode`, `quant_bands`, `rate`, `mathops`, `celt_lpc`, `vq` |
-| `entcode.c` | Range encoder utilities shared by `entenc`/`entdec`. | `entcode` |
 | `kiss_fft.c` | KISS FFT backend used by the MDCT. | `kiss_fft`, `mathops`, `stack_alloc` |
 | `mathops.c` | Fixed- and float-point math helpers beyond the ones already ported. | `mathops`, `float_cast` |
 | `mdct.c` | Forward/inverse MDCT built on top of KISS FFT. | `mdct`, `kiss_fft`, `mathops` |


### PR DESCRIPTION
## Summary
- match the unsigned division helper in `celt::entcode` to the reference implementation and document the lookup table origin
- expand the regression tests around `celt_udiv` to cover full divisor ranges and extreme numerators
- update the CELT porting status table to remove `entcode.c`, which is now fully mirrored in Rust

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68dd483b016c832aa6a41bb83b6acbb8