### PR TITLE
Port pitch search helpers from pitch.c

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -150,6 +150,12 @@ safely.
 - `pitch_downsample` &rarr; mirrors the low-pass downsampling stage implemented
   in `celt/pitch.c`, including the LPC-based pre-emphasis used before the pitch
   search.
+- `pitch_search` &rarr; ports the coarse-to-fine open-loop lag search from
+  `celt/pitch.c`, including the pseudo-interpolation that refines the best
+  candidate after the decimated sweeps.
+- `remove_doubling` &rarr; mirrors the subharmonic inspection helper from
+  `celt/pitch.c` that suppresses doubled pitch estimates and returns the
+  adjusted gain.
 
 ### `rate.rs`
 - `MAX_PSEUDO`, `LOG_MAX_PSEUDO`, `CELT_MAX_PULSES`, `MAX_FINE_BITS`,
@@ -196,7 +202,6 @@ support headers.
 | `kiss_fft.c` | KISS FFT backend used by the MDCT. | `kiss_fft`, `mathops`, `stack_alloc` |
 | `mdct.c` | Forward/inverse MDCT built on top of KISS FFT. | `mdct`, `kiss_fft`, `mathops` |
 | `modes.c` | Mode construction, static tables, precomputed caches. | `celt`, `modes`, `rate`, `quant_bands` |
-| `pitch.c` | Pitch correlation/search and postfilter helpers. | `modes`, `mathops`, `celt_lpc` |
 | `quant_bands.c` | Band quantisation tables and rate allocation. | `quant_bands`, `laplace`, `mathops`, `rate` |
 | `rate.c` | Remaining bitrate distribution heuristics (the helper constants and pulse cache builder now live in Rust). | `modes`, `cwrs`, `entcode`, `rate` |
 | `vq.c` (remaining parts) | Pulse allocation, PVQ search, and quantiser core. | `mathops`, `cwrs`, `bands`, `rate`, `pitch` |


### PR DESCRIPTION
## Summary
- port the remaining pitch search helpers from `celt/pitch.c`, including the coarse/fine sweep and pitch-doubling guard
- add unit tests that mirror the reference algorithms for the new functions
- update the CELT porting status to reflect the completed `pitch.c` module

## Testing
- cargo fmt
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68dd566d43c4832a850cfbba03e79ad7