### PR TITLE
Port CELT rate allocation routines

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -168,6 +168,12 @@ safely.
   pulse cache.
 - `compute_pulse_cache` &rarr; recreates the PVQ cache generation routine from
   `celt/rate.c`, including the per-band bit caps used by custom modes.
+- `interp_bits2pulses` &rarr; ports the allocation interpolation helper from
+  `celt/rate.c`, including the encode/decode logic for skip, intensity, and
+  dual-stereo signalling.
+- `clt_compute_allocation` &rarr; mirrors the top-level CELT allocation sweep
+  that searches the static vectors, applies trim offsets, and delegates to the
+  pulse interpolation helper.
 
 ### `quant_bands.rs`
 - `loss_distortion` &rarr; ports the distortion metric helper from
@@ -212,7 +218,6 @@ support headers.
 | `mdct.c` | Forward/inverse MDCT built on top of KISS FFT. | `mdct`, `kiss_fft`, `mathops` |
 | `modes.c` | Mode construction, static tables, precomputed caches. | `celt`, `modes`, `rate`, `quant_bands` |
 | `quant_bands.c` | Band quantisation tables and rate allocation. | `quant_bands`, `laplace`, `mathops`, `rate` |
-| `rate.c` | Remaining bitrate distribution heuristics (the helper constants and pulse cache builder now live in Rust). | `modes`, `cwrs`, `entcode`, `rate` |
 | `vq.c` (remaining parts) | Pulse allocation, PVQ search, and quantiser core. | `mathops`, `cwrs`, `bands`, `rate`, `pitch` |
 
 Additional directories (`arm/`, `mips/`, `x86/`) contain architecture-specific

--- a/src/celt/rate.rs
+++ b/src/celt/rate.rs
@@ -9,11 +9,14 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
+use core::cmp::{max, min};
 use core::convert::TryFrom;
 
 use crate::celt::cwrs::get_required_bits;
-use crate::celt::entcode::BITRES;
-use crate::celt::types::{OpusInt16, OpusInt32, PulseCacheData};
+use crate::celt::entcode::{BITRES, celt_udiv};
+use crate::celt::entdec::EcDec;
+use crate::celt::entenc::EcEnc;
+use crate::celt::types::{OpusCustomMode, OpusInt16, OpusInt32, OpusUint32, PulseCacheData};
 
 /// Maximum pseudo-pulse index described in the C headers.
 pub(crate) const MAX_PSEUDO: i32 = 40;
@@ -29,6 +32,11 @@ pub(crate) const FINE_OFFSET: i32 = 21;
 pub(crate) const QTHETA_OFFSET: i32 = 4;
 /// Offset applied when performing the two-phase qtheta search.
 pub(crate) const QTHETA_OFFSET_TWOPHASE: i32 = 16;
+
+/// Fractional log2 look-up table used when reserving intensity bits.
+pub(crate) const LOG2_FRAC_TABLE: [u8; 24] = [
+    0, 8, 13, 16, 19, 21, 23, 24, 26, 27, 28, 29, 30, 31, 32, 32, 33, 34, 34, 35, 36, 36, 37, 37,
+];
 
 /// Returns the number of pulses represented by the pseudo-pulse index `i`.
 ///
@@ -224,11 +232,447 @@ pub(crate) fn compute_pulse_cache(
     PulseCacheData::new(index, bits, caps)
 }
 
+/// Interpolates between allocation vectors and converts the resulting bit budget
+/// to PVQ pulses for each band.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
+pub(crate) fn interp_bits2pulses(
+    mode: &OpusCustomMode<'_>,
+    start: usize,
+    end: usize,
+    skip_start: usize,
+    bits1: &[OpusInt32],
+    bits2: &[OpusInt32],
+    thresh: &[OpusInt32],
+    cap: &[OpusInt32],
+    mut total: OpusInt32,
+    balance: &mut OpusInt32,
+    skip_rsv: OpusInt32,
+    intensity: &mut OpusInt32,
+    mut intensity_rsv: OpusInt32,
+    dual_stereo: &mut OpusInt32,
+    dual_stereo_rsv: OpusInt32,
+    bits: &mut [OpusInt32],
+    ebits: &mut [OpusInt32],
+    fine_priority: &mut [OpusInt32],
+    channels: OpusInt32,
+    lm: OpusInt32,
+    mut encoder: Option<&mut EcEnc<'_>>,
+    mut decoder: Option<&mut EcDec<'_>>,
+    prev: OpusInt32,
+    signal_bandwidth: OpusInt32,
+) -> OpusInt32 {
+    debug_assert!(start <= end);
+    debug_assert!(bits.len() >= end);
+    debug_assert!(ebits.len() >= end);
+    debug_assert!(fine_priority.len() >= end);
+    debug_assert!(bits1.len() >= end);
+    debug_assert!(bits2.len() >= end);
+    debug_assert!(thresh.len() >= end);
+    debug_assert!(cap.len() >= end);
+
+    const ALLOC_STEPS: OpusInt32 = 6;
+
+    let alloc_floor = channels << BITRES;
+    let stereo_shift = if channels > 1 { 1 } else { 0 };
+    let log_m = lm << BITRES;
+
+    let mut lo: OpusInt32 = 0;
+    let mut hi: OpusInt32 = 1 << ALLOC_STEPS;
+    for _ in 0..ALLOC_STEPS {
+        let mid = (lo + hi) >> 1;
+        let mut psum = 0;
+        let mut done = false;
+        for j in (start..end).rev() {
+            let tmp = bits1[j] + ((mid * bits2[j]) >> ALLOC_STEPS);
+            if tmp >= thresh[j] || done {
+                done = true;
+                psum += min(tmp, cap[j]);
+            } else if tmp >= alloc_floor {
+                psum += alloc_floor;
+            }
+        }
+        if psum > total {
+            hi = mid;
+        } else {
+            lo = mid;
+        }
+    }
+
+    let mut psum = 0;
+    let mut done = false;
+    for j in (start..end).rev() {
+        let mut tmp = bits1[j] + ((lo * bits2[j]) >> ALLOC_STEPS);
+        if tmp < thresh[j] && !done {
+            if tmp >= alloc_floor {
+                tmp = alloc_floor;
+            } else {
+                tmp = 0;
+            }
+        } else {
+            done = true;
+        }
+        tmp = min(tmp, cap[j]);
+        bits[j] = tmp;
+        psum += tmp;
+    }
+
+    let mut coded_bands = end as OpusInt32;
+    while coded_bands > start as OpusInt32 {
+        let band = coded_bands - 1;
+        let j = band as usize;
+        let band_start = OpusInt32::from(mode.e_bands[start]);
+        let band_end = OpusInt32::from(mode.e_bands[coded_bands as usize]);
+        let band_prev = OpusInt32::from(mode.e_bands[j]);
+        let band_width = band_end - band_prev;
+
+        if band <= skip_start as OpusInt32 {
+            total += skip_rsv;
+            break;
+        }
+
+        let mut left = total - psum;
+        let denom = max(band_end - band_start, 1);
+        let per_coeff = celt_udiv(left.max(0) as OpusUint32, denom as OpusUint32) as OpusInt32;
+        left -= denom * per_coeff;
+        let rem = max(left - (band_prev - band_start), 0);
+        let mut band_bits = bits[j] + per_coeff * band_width + rem;
+        let thresh_j = max(thresh[j], alloc_floor + (1 << BITRES));
+
+        if band_bits >= thresh_j {
+            let mut skip = false;
+            if let Some(enc) = encoder.as_deref_mut() {
+                let decision = if coded_bands > 17 {
+                    let depth_threshold = if j as OpusInt32 <= prev { 7 } else { 9 };
+                    let split_shift = (lm + BITRES as OpusInt32) as u32;
+                    band_bits > ((depth_threshold * band_width) << split_shift) >> 4
+                        && (j as OpusInt32) <= signal_bandwidth
+                } else {
+                    true
+                };
+                enc.enc_bit_logp(decision as OpusInt32, 1);
+                if decision {
+                    skip = true;
+                }
+            } else if let Some(dec) = decoder.as_deref_mut() {
+                if dec.dec_bit_logp(1) != 0 {
+                    skip = true;
+                }
+            }
+
+            if skip {
+                break;
+            }
+
+            psum += 1 << BITRES;
+            band_bits -= 1 << BITRES;
+        }
+
+        psum -= bits[j] + intensity_rsv;
+        if intensity_rsv > 0 {
+            intensity_rsv = OpusInt32::from(LOG2_FRAC_TABLE[j - start]);
+        }
+        psum += intensity_rsv;
+
+        if band_bits >= alloc_floor {
+            psum += alloc_floor;
+            bits[j] = alloc_floor;
+        } else {
+            bits[j] = 0;
+        }
+
+        coded_bands -= 1;
+    }
+
+    debug_assert!(coded_bands > start as OpusInt32);
+
+    if intensity_rsv > 0 {
+        if let Some(enc) = encoder.as_deref_mut() {
+            let limit = coded_bands + 1 - start as OpusInt32;
+            let clamped = min(*intensity, coded_bands);
+            enc.enc_uint((clamped - start as OpusInt32) as OpusUint32, limit as u32);
+        } else if let Some(dec) = decoder.as_deref_mut() {
+            let limit = coded_bands + 1 - start as OpusInt32;
+            let value = dec.dec_uint(limit as u32) as OpusInt32;
+            *intensity = start as OpusInt32 + value;
+        }
+    } else {
+        *intensity = 0;
+    }
+
+    if *intensity <= start as OpusInt32 {
+        total += dual_stereo_rsv;
+    }
+
+    if dual_stereo_rsv > 0 {
+        if let Some(enc) = encoder.as_deref_mut() {
+            enc.enc_bit_logp(*dual_stereo, 1);
+        } else if let Some(dec) = decoder.as_deref_mut() {
+            *dual_stereo = dec.dec_bit_logp(1);
+        }
+    } else {
+        *dual_stereo = 0;
+    }
+
+    let denom = max(
+        OpusInt32::from(mode.e_bands[coded_bands as usize]) - OpusInt32::from(mode.e_bands[start]),
+        1,
+    );
+    let mut left = total - psum;
+    let per_coeff = celt_udiv(left.max(0) as OpusUint32, denom as OpusUint32) as OpusInt32;
+    left -= denom * per_coeff;
+    for j in start..coded_bands as usize {
+        let width = OpusInt32::from(mode.e_bands[j + 1] - mode.e_bands[j]);
+        bits[j] += per_coeff * width;
+    }
+    for j in start..coded_bands as usize {
+        let width = OpusInt32::from(mode.e_bands[j + 1] - mode.e_bands[j]);
+        let add = min(width, left);
+        bits[j] += add;
+        left -= add;
+    }
+
+    let mut local_balance = 0;
+    for j in start..coded_bands as usize {
+        let n0 = OpusInt32::from(mode.e_bands[j + 1] - mode.e_bands[j]);
+        let n = n0 << lm;
+        let bit = bits[j] + local_balance;
+
+        if n > 1 {
+            let excess = max(bit - cap[j], 0);
+            bits[j] = bit - excess;
+
+            let mut den = channels * n;
+            if channels == 2 && n > 2 && *dual_stereo == 0 && (j as OpusInt32) < *intensity {
+                den += 1;
+            }
+            let nclogn = den * (OpusInt32::from(mode.log_n[j]) + log_m);
+            let mut offset = (nclogn >> 1) - den * FINE_OFFSET;
+            if n == 2 {
+                offset += den << (BITRES - 2);
+            }
+            if bits[j] + offset < den * 2 << BITRES {
+                offset += nclogn >> 2;
+            } else if bits[j] + offset < den * 3 << BITRES {
+                offset += nclogn >> 3;
+            }
+
+            let mut eb = max(0, bits[j] + offset + (den << (BITRES - 1)));
+            eb = (celt_udiv(eb as OpusUint32, den as OpusUint32) as OpusInt32) >> BITRES;
+            if channels * eb > (bits[j] >> stereo_shift) >> BITRES {
+                eb = bits[j] >> stereo_shift >> BITRES;
+            }
+            eb = min(eb, MAX_FINE_BITS);
+            fine_priority[j] = if eb * (den << BITRES) >= bits[j] + offset {
+                1
+            } else {
+                0
+            };
+            bits[j] -= channels * eb << BITRES;
+            ebits[j] = eb;
+
+            if excess > 0 {
+                let extra_fine = min(excess >> (stereo_shift + BITRES), MAX_FINE_BITS - ebits[j]);
+                ebits[j] += extra_fine;
+                let extra_bits = extra_fine * channels << BITRES;
+                if extra_bits >= excess - local_balance {
+                    fine_priority[j] = 1;
+                }
+                local_balance = excess - extra_bits;
+            } else {
+                local_balance = excess;
+            }
+        } else {
+            let excess = max(0, bit - (channels << BITRES));
+            bits[j] = bit - excess;
+            ebits[j] = 0;
+            fine_priority[j] = 1;
+            local_balance = excess;
+        }
+
+        debug_assert!(bits[j] >= 0);
+        debug_assert!(ebits[j] >= 0);
+    }
+
+    *balance = local_balance;
+    coded_bands
+}
+
+/// Computes the full band allocation curve for the supplied mode and bit budget.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
+pub(crate) fn clt_compute_allocation(
+    mode: &OpusCustomMode<'_>,
+    start: usize,
+    end: usize,
+    offsets: &[OpusInt32],
+    cap: &[OpusInt32],
+    alloc_trim: OpusInt32,
+    intensity: &mut OpusInt32,
+    dual_stereo: &mut OpusInt32,
+    mut total: OpusInt32,
+    balance: &mut OpusInt32,
+    pulses: &mut [OpusInt32],
+    ebits: &mut [OpusInt32],
+    fine_priority: &mut [OpusInt32],
+    channels: OpusInt32,
+    lm: OpusInt32,
+    encoder: Option<&mut EcEnc<'_>>,
+    decoder: Option<&mut EcDec<'_>>,
+    prev: OpusInt32,
+    signal_bandwidth: OpusInt32,
+) -> OpusInt32 {
+    debug_assert!(offsets.len() >= end);
+    debug_assert!(cap.len() >= end);
+    debug_assert!(pulses.len() >= end);
+    debug_assert!(ebits.len() >= end);
+    debug_assert!(fine_priority.len() >= end);
+
+    total = max(total, 0);
+    let len = mode.num_ebands;
+    let mut skip_start = start;
+
+    let mut skip_rsv = 0;
+    if total >= 1 << BITRES {
+        skip_rsv = 1 << BITRES;
+        total -= skip_rsv;
+    }
+
+    let mut intensity_rsv = 0;
+    let mut dual_stereo_rsv = 0;
+    if channels == 2 {
+        let candidate = OpusInt32::from(LOG2_FRAC_TABLE[end - start]);
+        if candidate <= total {
+            intensity_rsv = candidate;
+            total -= intensity_rsv;
+            if total >= 1 << BITRES {
+                dual_stereo_rsv = 1 << BITRES;
+                total -= dual_stereo_rsv;
+            }
+        }
+    }
+
+    let mut bits1 = vec![0; len];
+    let mut bits2 = vec![0; len];
+    let mut thresh = vec![0; len];
+    let mut trim_offset = vec![0; len];
+
+    for j in start..end {
+        let n = OpusInt32::from(mode.e_bands[j + 1] - mode.e_bands[j]);
+        let alloc_shift = (lm + BITRES as OpusInt32) as u32;
+        thresh[j] = max(channels << BITRES, (3 * n) << alloc_shift >> 4);
+        let split_shift = (lm + BITRES as OpusInt32) as u32;
+        trim_offset[j] = channels
+            * n
+            * (alloc_trim - 5 - lm)
+            * OpusInt32::try_from(end - j - 1).unwrap()
+            * (1 << split_shift)
+            >> 6;
+        if (n << lm) == 1 {
+            trim_offset[j] -= channels << BITRES;
+        }
+    }
+
+    let mut lo: OpusInt32 = 1;
+    let mut hi: OpusInt32 = mode.num_alloc_vectors as OpusInt32 - 1;
+    while lo <= hi {
+        let mid = (lo + hi) >> 1;
+        let mut done = false;
+        let mut psum = 0;
+        for j in (start..end).rev() {
+            let n = OpusInt32::from(mode.e_bands[j + 1] - mode.e_bands[j]);
+            let mut bitsj =
+                channels * n * OpusInt32::from(mode.alloc_vectors[mid as usize * len + j]) << lm
+                    >> 2;
+            if bitsj > 0 {
+                bitsj = max(0, bitsj + trim_offset[j]);
+            }
+            bitsj += offsets[j];
+            if bitsj >= thresh[j] || done {
+                done = true;
+                psum += min(bitsj, cap[j]);
+            } else if bitsj >= channels << BITRES {
+                psum += channels << BITRES;
+            }
+        }
+        if psum > total {
+            hi = mid - 1;
+        } else {
+            lo = mid + 1;
+        }
+    }
+
+    hi = lo;
+    lo -= 1;
+
+    for j in start..end {
+        let n = OpusInt32::from(mode.e_bands[j + 1] - mode.e_bands[j]);
+        let mut bits1j =
+            channels * n * OpusInt32::from(mode.alloc_vectors[lo as usize * len + j]) << lm >> 2;
+        let mut bits2j = if hi as usize >= mode.num_alloc_vectors {
+            cap[j]
+        } else {
+            channels * n * OpusInt32::from(mode.alloc_vectors[hi as usize * len + j]) << lm >> 2
+        };
+        if bits1j > 0 {
+            bits1j = max(0, bits1j + trim_offset[j]);
+        }
+        if bits2j > 0 {
+            bits2j = max(0, bits2j + trim_offset[j]);
+        }
+        if lo > 0 {
+            bits1j += offsets[j];
+        }
+        bits2j += offsets[j];
+        if offsets[j] > 0 {
+            skip_start = j;
+        }
+        bits2j = max(0, bits2j - bits1j);
+        bits1[j] = bits1j;
+        bits2[j] = bits2j;
+    }
+
+    interp_bits2pulses(
+        mode,
+        start,
+        end,
+        skip_start,
+        &bits1,
+        &bits2,
+        &thresh,
+        cap,
+        total,
+        balance,
+        skip_rsv,
+        intensity,
+        intensity_rsv,
+        dual_stereo,
+        dual_stereo_rsv,
+        pulses,
+        ebits,
+        fine_priority,
+        channels,
+        lm,
+        encoder,
+        decoder,
+        prev,
+        signal_bandwidth,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::collections::BTreeMap;
+    use alloc::vec;
 
-    use super::{compute_pulse_cache, fits_in32, get_pulses};
+    use super::{
+        LOG2_FRAC_TABLE, clt_compute_allocation, compute_pulse_cache, fits_in32, get_pulses,
+        interp_bits2pulses,
+    };
+    use crate::celt::entcode::BITRES;
+    use crate::celt::entdec::EcDec;
+    use crate::celt::entenc::EcEnc;
+    use crate::celt::types::{MdctLookup, OpusCustomMode, OpusInt32, PulseCacheData};
 
     #[test]
     fn get_pulses_matches_reference_pattern() {
@@ -294,5 +738,215 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn simple_mode<'a>(
+        e_bands: &'a [i16],
+        alloc_vectors: &'a [u8],
+        log_n: &'a [i16],
+        cache: PulseCacheData,
+    ) -> OpusCustomMode<'a> {
+        OpusCustomMode {
+            sample_rate: 48_000,
+            overlap: 0,
+            num_ebands: e_bands.len(),
+            effective_ebands: e_bands.len(),
+            pre_emphasis: [0.0; 4],
+            e_bands,
+            max_lm: 2,
+            num_short_mdcts: 0,
+            short_mdct_size: 0,
+            num_alloc_vectors: alloc_vectors.len() / e_bands.len(),
+            alloc_vectors,
+            log_n,
+            window: &[],
+            mdct: MdctLookup::new(0, 0, &[]),
+            cache,
+        }
+    }
+
+    #[test]
+    fn interp_bits2pulses_matches_encode_decode() {
+        let e_bands = [0i16, 2, 4];
+        let log_n = [7i16, 8];
+        let alloc_vectors = [6u8, 7, 9, 10];
+        let cache = compute_pulse_cache(&e_bands, &log_n, 1);
+        let mode = simple_mode(&e_bands, &alloc_vectors, &log_n, cache);
+
+        let cap = vec![1 << (BITRES + 6); mode.num_ebands];
+        let bits1 = vec![20 << BITRES; mode.num_ebands];
+        let bits2 = vec![5 << BITRES; mode.num_ebands];
+        let thresh = vec![8 << BITRES; mode.num_ebands];
+        let mut bits_encode = vec![0; mode.num_ebands];
+        let mut bits_decode = vec![0; mode.num_ebands];
+        let mut ebits_encode = vec![0; mode.num_ebands];
+        let mut ebits_decode = vec![0; mode.num_ebands];
+        let mut fine_encode = vec![0; mode.num_ebands];
+        let mut fine_decode = vec![0; mode.num_ebands];
+        let mut balance_encode = 0;
+        let mut balance_decode = 0;
+        let mut intensity_encode = 0;
+        let mut intensity_decode = 0;
+        let mut dual_stereo_encode = 0;
+        let mut dual_stereo_decode = 0;
+        let total = 120 << BITRES;
+
+        let mut buffer = vec![0u8; 64];
+        {
+            let mut enc = EcEnc::new(&mut buffer);
+            interp_bits2pulses(
+                &mode,
+                0,
+                2,
+                0,
+                &bits1,
+                &bits2,
+                &thresh,
+                &cap,
+                total,
+                &mut balance_encode,
+                1 << BITRES,
+                &mut intensity_encode,
+                OpusInt32::from(LOG2_FRAC_TABLE[2]),
+                &mut dual_stereo_encode,
+                1 << BITRES,
+                &mut bits_encode,
+                &mut ebits_encode,
+                &mut fine_encode,
+                1,
+                1,
+                Some(&mut enc),
+                None,
+                0,
+                2,
+            );
+            enc.enc_done();
+        }
+
+        let mut decode_buf = buffer.clone();
+        {
+            let mut dec = EcDec::new(&mut decode_buf);
+            interp_bits2pulses(
+                &mode,
+                0,
+                2,
+                0,
+                &bits1,
+                &bits2,
+                &thresh,
+                &cap,
+                total,
+                &mut balance_decode,
+                1 << BITRES,
+                &mut intensity_decode,
+                OpusInt32::from(LOG2_FRAC_TABLE[2]),
+                &mut dual_stereo_decode,
+                1 << BITRES,
+                &mut bits_decode,
+                &mut ebits_decode,
+                &mut fine_decode,
+                1,
+                1,
+                None,
+                Some(&mut dec),
+                0,
+                2,
+            );
+        }
+
+        assert_eq!(bits_encode, bits_decode);
+        assert_eq!(ebits_encode, ebits_decode);
+        assert_eq!(fine_encode, fine_decode);
+        assert_eq!(balance_encode, balance_decode);
+        assert_eq!(intensity_encode, intensity_decode);
+        assert_eq!(dual_stereo_encode, dual_stereo_decode);
+    }
+
+    #[test]
+    fn clt_compute_allocation_round_trip() {
+        let e_bands = [0i16, 2, 4];
+        let log_n = [7i16, 8];
+        let alloc_vectors = [6u8, 8, 9, 11];
+        let cache = compute_pulse_cache(&e_bands, &log_n, 1);
+        let mode = simple_mode(&e_bands, &alloc_vectors, &log_n, cache);
+
+        let offsets = vec![0; mode.num_ebands];
+        let cap = vec![1 << (BITRES + 6); mode.num_ebands];
+        let total = 140 << BITRES;
+
+        let mut pulses_encode = vec![0; mode.num_ebands];
+        let mut pulses_decode = vec![0; mode.num_ebands];
+        let mut ebits_encode = vec![0; mode.num_ebands];
+        let mut ebits_decode = vec![0; mode.num_ebands];
+        let mut fine_encode = vec![0; mode.num_ebands];
+        let mut fine_decode = vec![0; mode.num_ebands];
+        let mut balance_encode = 0;
+        let mut balance_decode = 0;
+        let mut intensity_encode = 0;
+        let mut intensity_decode = 0;
+        let mut dual_stereo_encode = 0;
+        let mut dual_stereo_decode = 0;
+
+        let coded_bands_encode;
+        let mut buffer = vec![0u8; 64];
+        {
+            let mut enc = EcEnc::new(&mut buffer);
+            coded_bands_encode = clt_compute_allocation(
+                &mode,
+                0,
+                2,
+                &offsets,
+                &cap,
+                5,
+                &mut intensity_encode,
+                &mut dual_stereo_encode,
+                total,
+                &mut balance_encode,
+                &mut pulses_encode,
+                &mut ebits_encode,
+                &mut fine_encode,
+                1,
+                1,
+                Some(&mut enc),
+                None,
+                0,
+                2,
+            );
+            enc.enc_done();
+        }
+
+        let mut decode_buf = buffer.clone();
+        {
+            let mut dec = EcDec::new(&mut decode_buf);
+            let coded_bands_decode = clt_compute_allocation(
+                &mode,
+                0,
+                2,
+                &offsets,
+                &cap,
+                5,
+                &mut intensity_decode,
+                &mut dual_stereo_decode,
+                total,
+                &mut balance_decode,
+                &mut pulses_decode,
+                &mut ebits_decode,
+                &mut fine_decode,
+                1,
+                1,
+                None,
+                Some(&mut dec),
+                0,
+                2,
+            );
+            assert_eq!(coded_bands_decode, coded_bands_encode);
+        }
+
+        assert_eq!(pulses_encode, pulses_decode);
+        assert_eq!(ebits_encode, ebits_decode);
+        assert_eq!(fine_encode, fine_decode);
+        assert_eq!(balance_encode, balance_decode);
+        assert_eq!(intensity_encode, intensity_decode);
+        assert_eq!(dual_stereo_encode, dual_stereo_decode);
     }
 }


### PR DESCRIPTION
## Summary
- port the CELT rate control helpers that interpolate allocation vectors and compute the final per-band pulse budgets
- add round-trip tests covering the new allocation routines in both encoder and decoder modes
- update the porting status document to note the completed rate module

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68dd5dbc7838832ab43ee0d216937bed