### PR TITLE
Port Haar transform helper

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -30,6 +30,9 @@ safely.
 - `stereo_merge` &rarr; mirrors the float mid/side reconstruction helper from
   `celt/bands.c`, including the energy guards and normalisation gains used when
   converting encoded mid/side pairs back to left/right channels.
+- `haar1` &rarr; ports the single-level Haar transform from `celt/bands.c` that
+  mixes adjacent interleaved coefficients using an orthonormal sum/difference
+  stage.
 
 ### `math.rs`
 - `fast_atan2f` &rarr; mirrors the helper of the same name in


### PR DESCRIPTION
## Summary
- port the haar1 helper from `celt/bands.c` into the Rust `bands` module and exercise it with an orthonormality test
- document the newly ported helper in `PORTING_STATUS.md`

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68df7c12ce6c832a8ebaf0bf57d5d62d