### PR TITLE
Port collapse mask and residual helpers from vq.c

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -88,6 +88,12 @@ safely.
   definitions in `celt/bands.h` and `celt/vq.c`.
 - `exp_rotation` and the helper `exp_rotation1` &rarr; mirror the coefficient
   rotation routines in `celt/vq.c`.
+- `normalise_residual` &rarr; ports the decoder/encoder helper in `celt/vq.c`
+  that scales the quantised pulse vector by the pitch gain so the mixed
+  excitation preserves unit energy.
+- `extract_collapse_mask` &rarr; mirrors the collapse mask generator from
+  `celt/vq.c`, grouping PVQ pulses per band to flag spectral regions that need
+  spreading after quantisation.
 
 ### `laplace.rs`
 - `ec_laplace_encode`, `ec_laplace_decode`, `ec_laplace_encode_p0`, and

--- a/src/celt/vq.rs
+++ b/src/celt/vq.rs
@@ -7,8 +7,9 @@
 //! map closely to their C counterparts, making them ideal candidates for early
 //! porting efforts.
 
-use crate::celt::math::{celt_cos_norm, celt_div};
-use crate::celt::types::OpusVal16;
+use crate::celt::entcode::celt_udiv;
+use crate::celt::math::{celt_cos_norm, celt_div, celt_rsqrt_norm};
+use crate::celt::types::{OpusVal16, OpusVal32};
 
 /// Spread decisions mirrored from `celt/bands.h`.
 pub(crate) const SPREAD_NONE: i32 = 0;
@@ -116,11 +117,80 @@ pub(crate) fn exp_rotation(
     }
 }
 
+/// Port of `normalise_residual()` from `celt/vq.c`.
+///
+/// The helper mixes the decoded PVQ pulses with the pitch vector so that the
+/// resulting excitation has unit energy. The float build performs the scaling
+/// by computing the reciprocal square root of the accumulated pulse energy and
+/// multiplying by the supplied gain. The Rust port follows the same approach
+/// while clamping the slice lengths to avoid overruns.
+pub(crate) fn normalise_residual(
+    pulses: &[i32],
+    x: &mut [OpusVal16],
+    n: usize,
+    ryy: OpusVal32,
+    gain: OpusVal32,
+) {
+    if n == 0 {
+        return;
+    }
+
+    debug_assert!(pulses.len() >= n, "pulse buffer shorter than band size");
+    debug_assert!(x.len() >= n, "output buffer shorter than band size");
+
+    let len = n.min(pulses.len()).min(x.len());
+    if len == 0 {
+        return;
+    }
+
+    let scale = celt_rsqrt_norm(ryy) * gain;
+    for (dst, &pulse) in x.iter_mut().take(len).zip(pulses.iter()) {
+        *dst = scale * pulse as OpusVal16;
+    }
+}
+
+/// Mirrors `extract_collapse_mask()` from `celt/vq.c`.
+///
+/// The helper inspects the quantised PVQ pulses and determines which of the
+/// folded bands received any energy. The mask is later used to decide whether
+/// a band "collapsed" during quantisation and therefore needs spectral
+/// spreading in the decoder.
+#[must_use]
+pub(crate) fn extract_collapse_mask(pulses: &[i32], n: usize, b: usize) -> u32 {
+    if b <= 1 {
+        return 1;
+    }
+
+    if n == 0 {
+        return 0;
+    }
+
+    debug_assert!(pulses.len() >= n, "pulse buffer shorter than band size");
+
+    let n0 = celt_udiv(n as u32, b as u32) as usize;
+    debug_assert!(n0 > 0, "sub-band width must be non-zero");
+
+    let mut collapse_mask = 0u32;
+    for band in 0..b {
+        let start = band * n0;
+        let end = (start + n0).min(pulses.len());
+        let mut accumulator = 0;
+        for &value in &pulses[start..end] {
+            accumulator |= value;
+        }
+        if accumulator != 0 {
+            collapse_mask |= 1 << band;
+        }
+    }
+
+    collapse_mask
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
 
-    use super::{SPREAD_NORMAL, exp_rotation};
+    use super::{SPREAD_NORMAL, exp_rotation, extract_collapse_mask, normalise_residual};
 
     fn seed_samples(len: usize) -> Vec<f32> {
         let mut seed = 0x1234_5678u32;
@@ -169,5 +239,37 @@ mod tests {
         for &(len, k) in &[(15, 3), (23, 5), (50, 3), (80, 1)] {
             rotation_case(len, k);
         }
+    }
+
+    #[test]
+    fn residual_normalisation_scales_by_gain() {
+        let pulses = [2, -1, 0, 3];
+        let mut output = [0.0f32; 4];
+        let ryy = 25.0;
+        let gain = 0.5;
+
+        normalise_residual(&pulses, &mut output, pulses.len(), ryy, gain);
+
+        let expected_scale = gain * (1.0 / ryy.sqrt());
+        for (value, &pulse) in output.iter().zip(&pulses) {
+            let expected = expected_scale * pulse as f32;
+            assert!(
+                (value - expected).abs() <= 1e-6,
+                "expected {expected}, found {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn collapse_mask_sets_bits_for_active_bands() {
+        let pulses = [0, 0, 1, 0, 0, 0, 2, 3];
+        let mask = extract_collapse_mask(&pulses, pulses.len(), 4);
+        assert_eq!(mask, 0b1010);
+    }
+
+    #[test]
+    fn collapse_mask_for_single_band_is_one() {
+        let pulses = [0, 0, 0, 0];
+        assert_eq!(extract_collapse_mask(&pulses, pulses.len(), 1), 1);
     }
 }


### PR DESCRIPTION
## Summary
- port the normalise_residual and extract_collapse_mask helpers from celt/vq.c into the Rust VQ module
- add dedicated unit tests exercising the new helpers
- update the CELT porting status document to reflect the additional coverage

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68dfe21cc1cc832a837588c59c4e22c8