### PR TITLE
Port compute_allocation_table helper from modes.c

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -221,6 +221,9 @@ safely.
 - `compute_ebands` &rarr; ports the Bark-scale band layout generator from
   `celt/modes.c`, returning the dynamic band edges used when constructing custom
   CELT modes.
+- `compute_allocation_table` &rarr; ports the allocation vector interpolation
+  helper from `celt/modes.c`, remapping the 5 ms reference bit-allocation table
+  to the dynamically generated Bark-based band layout used by custom modes.
 
 ### `kiss_fft.rs`
 - `KissFftState` &rarr; safe Rust wrapper around the scalar KISS FFT routines in


### PR DESCRIPTION
## Summary
- port the `compute_allocation_table` helper from `celt/modes.c`, exposing allocation-table metadata alongside the reference bit-allocation matrix
- add unit tests covering the stock 5 ms configuration and an interpolated custom layout
- update the CELT porting status to record the new Rust coverage

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68e0c4a7b274832a9a35a19ecf60b954