### PR TITLE
Port resampling_factor helper from celt.c

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -43,6 +43,11 @@ safely.
   `celt/bands.c`, applying the stride-specific permutation that positions the DC
   term at the end of each band block.
 
+### `celt.rs`
+- `resampling_factor` &rarr; mirrors the sampling-rate-to-downsampling-factor
+  mapping in `celt/celt.c`, returning the ratios used by the pitch analysis
+  when converting from the 48 kHz reference rate.
+
 ### `math.rs`
 - `fast_atan2f` &rarr; mirrors the helper of the same name in
   `celt/mathops.h`.

--- a/src/celt/celt.rs
+++ b/src/celt/celt.rs
@@ -1,0 +1,49 @@
+#![allow(dead_code)]
+
+//! Helpers ported from `celt/celt.c`.
+//!
+//! This module starts translating small pieces of the CELT top-level glue. The
+//! helpers exposed here have no dependencies on the rest of the encoder or
+//! decoder state so they can be exercised in isolation while larger control
+//! flow is still being translated.
+
+use crate::celt::types::OpusInt32;
+
+/// Returns the downsampling factor that maps the 48 kHz reference rate to the
+/// provided sampling rate.
+///
+/// Mirrors the behaviour of `resampling_factor()` from `celt/celt.c`, which is
+/// used to derive the coarse pitch analysis stride. Unsupported sampling rates
+/// fall back to zero just like the reference implementation when custom modes
+/// are enabled.
+#[must_use]
+pub(crate) fn resampling_factor(rate: OpusInt32) -> u32 {
+    match rate {
+        48_000 => 1,
+        24_000 => 2,
+        16_000 => 3,
+        12_000 => 4,
+        8_000 => 6,
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resampling_factor;
+
+    #[test]
+    fn matches_reference_mapping() {
+        assert_eq!(resampling_factor(48_000), 1);
+        assert_eq!(resampling_factor(24_000), 2);
+        assert_eq!(resampling_factor(16_000), 3);
+        assert_eq!(resampling_factor(12_000), 4);
+        assert_eq!(resampling_factor(8_000), 6);
+    }
+
+    #[test]
+    fn returns_zero_for_unsupported_rates() {
+        assert_eq!(resampling_factor(44_100), 0);
+        assert_eq!(resampling_factor(96_000), 0);
+    }
+}

--- a/src/celt/mod.rs
+++ b/src/celt/mod.rs
@@ -6,6 +6,7 @@
 //! relying on Rust's ownership and lifetime tracking for safety.
 
 mod bands;
+mod celt;
 mod cpu_support;
 mod cwrs;
 mod entcode;
@@ -27,6 +28,8 @@ mod vq;
 
 #[allow(unused_imports)]
 pub(crate) use bands::*;
+#[allow(unused_imports)]
+pub(crate) use celt::*;
 #[allow(unused_imports)]
 pub(crate) use cpu_support::*;
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary
- port the `resampling_factor` helper from `celt/celt.c` into a new `celt.rs` module and re-export it through the CELT module tree
- update the porting status document to reflect the newly translated helper

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68e0f41cfa20832a8f75edf3d84dd1bd