### PR TITLE
Port anti collapse helper for collapsed bands

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -22,6 +22,9 @@ safely.
 - `intensity_stereo` &rarr; mirrors the intensity mixing helper from
   `celt/bands.c` that reconstructs mid-channel samples from the
   intensity-coded side data using the per-band energy weights.
+- `anti_collapse` &rarr; recreates the transient noise injection used in
+  `celt/bands.c` to repopulate collapsed short MDCT bands and renormalises the
+  affected coefficients after seeding the pseudo-random spectrum.
 - `compute_band_energies` &rarr; ports the float helper from `celt/bands.c`
   that accumulates per-band MDCT magnitudes before normalisation.
 - `normalise_bands` &rarr; mirrors the float implementation from


### PR DESCRIPTION
## Summary
- port the float anti_collapse transient-recovery helper from celt/bands.c
- add a focused unit test that verifies noise injection and renormalisation
- document the new coverage in PORTING_STATUS.md

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68e130ee05a4832a8dadfcca7a5c597e