### PR TITLE
Port sampling-rate preemphasis helper from modes.c

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -259,6 +259,9 @@ safely.
 - `compute_allocation_table` &rarr; ports the allocation vector interpolation
   helper from `celt/modes.c`, remapping the 5 ms reference bit-allocation table
   to the dynamically generated Bark-based band layout used by custom modes.
+- `compute_preemphasis` &rarr; mirrors the sampling-rate-dependent pre-emphasis
+  tap selection from `celt/modes.c`, returning the four filter coefficients used
+  to initialise `mode->preemph` during custom mode construction.
 
 ### `kiss_fft.rs`
 - `KissFftState` &rarr; safe Rust wrapper around the scalar KISS FFT routines in


### PR DESCRIPTION
## Summary
- add a `compute_preemphasis` helper that mirrors the sampling-rate specific pre-emphasis taps from `celt/modes.c`
- cover the helper with unit tests alongside the existing allocation tests
- record the newly ported routine in `PORTING_STATUS.md`

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68e22105ac74832a9beaae20629a22ae