### PR TITLE
Port opus_custom_mode_create

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -272,6 +272,10 @@ safely.
 - `compute_log_band_widths` &rarr; mirrors the loop in `opus_custom_mode_create()`
   that fills the `logN` table by applying `log2_frac()` to each Bark-derived
   band width, preserving the `BITRES` fractional precision.
+- `opus_custom_mode_create` and `OwnedOpusCustomMode` &rarr; port the dynamic
+  mode constructor from `celt/modes.c`, validating inputs, generating the Bark
+  layout, allocation tables, MDCT lookup, and pulse caches, and wrapping the
+  results in a safe owner that mirrors the lifetime of `CELTMode`.
 
 ### `kiss_fft.rs`
 - `KissFftState` &rarr; safe Rust wrapper around the scalar KISS FFT routines in

--- a/src/celt/bands.rs
+++ b/src/celt/bands.rs
@@ -858,8 +858,8 @@ mod tests {
     #[test]
     fn intensity_stereo_matches_reference_weights() {
         let e_bands = [0i16, 2, 4, 6, 8];
-        let alloc_vectors = [0u8; 5];
-        let log_n = [0i16; 5];
+        let alloc_vectors = [0u8; 4];
+        let log_n = [0i16; 4];
         let window = [0.0f32; 4];
         let mdct = MdctLookup::new(4, 0);
         let mode = OpusCustomMode::new(

--- a/src/celt/quant_bands.rs
+++ b/src/celt/quant_bands.rs
@@ -958,7 +958,7 @@ mod tests {
 
     #[test]
     fn fine_energy_quantisation_round_trips() {
-        let e_bands = [0i16; 4];
+        let e_bands = [0i16, 1, 2, 3, 4];
         let alloc_vectors = [0u8; 4];
         let log_n = [0i16; 4];
         let window = [0.0f32; 4];
@@ -1042,7 +1042,7 @@ mod tests {
 
     #[test]
     fn coarse_energy_round_trip_matches_encoder() {
-        let e_bands = [0i16; 6];
+        let e_bands = [0i16, 1, 2, 3, 4, 5, 6];
         let alloc_vectors = [0u8; 6];
         let log_n = [0i16; 6];
         let window = [0.0f32; 6];
@@ -1125,7 +1125,7 @@ mod tests {
 
     #[test]
     fn amp2_log2_matches_expected_logarithm() {
-        let e_bands = [0i16; 6];
+        let e_bands = [0i16, 1, 2, 3, 4, 5, 6];
         let alloc_vectors = [0u8; 6];
         let log_n = [0i16; 6];
         let window = [0.0f32; 6];
@@ -1154,7 +1154,7 @@ mod tests {
 
     #[test]
     fn log2_amp_restores_linear_energies() {
-        let e_bands = [0i16; 6];
+        let e_bands = [0i16, 1, 2, 3, 4, 5, 6];
         let alloc_vectors = [0u8; 6];
         let log_n = [0i16; 6];
         let window = [0.0f32; 6];


### PR DESCRIPTION
## Summary
- port `opus_custom_mode_create` by introducing `ModeError`, `OwnedOpusCustomMode`, and construction tests for dynamic CELT modes
- relax `MdctLookup::new` requirements, update `OpusCustomMode::new` band/allocator metadata, and adjust CELT tests to use sentinel band layouts
- document the newly ported mode creation logic in `PORTING_STATUS.md`

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68e274b58628832aa67d0e9504eb970f