### PR TITLE
Port compute_qn helper from CELT bands module

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -45,6 +45,10 @@ safely.
 - `interleave_hadamard` &rarr; ports the Hadamard interleaver from
   `celt/bands.c`, applying the stride-specific permutation that positions the DC
   term at the end of each band block.
+- `compute_qn` &rarr; ports the helper from `celt/bands.c` that selects the
+  number of quantisation levels used for the stereo angle, capping the
+  resolution to guarantee that at least one pulse remains available for the side
+  channel.
 - `spreading_decision` &rarr; ports the frame-level spreading classifier from
   `celt/bands.c`, building per-band histograms, smoothing the score, and
   applying the hysteresis used to stabilise PVQ spreading decisions while


### PR DESCRIPTION
## Summary
- port the `compute_qn` helper from `celt/bands.c` into the Rust `bands` module
- add targeted unit tests to exercise the new quantisation-level calculation
- update the CELT porting status document to capture the newly ported helper

## Testing
- cargo fmt
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68e28bb70094832a8481ac56f20c7692