### PR TITLE
Port float_cast helpers to Rust

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -150,6 +150,15 @@ safely.
   detection stub from `celt/cpu_support.h`, returning zero when runtime dispatch
   is disabled.
 
+### `float_cast.rs`
+- `CELT_SIG_SCALE` &rarr; exposes the floating-point scaling factor defined in
+  `celt/float_cast.h` that bridges the public float API and the fixed-point
+  internals.
+- `float2int` &rarr; ports the rounding helper built on top of `lrintf()` to
+  obtain saturated 32-bit integers from `f32` inputs.
+- `float2int16` &rarr; mirrors the `FLOAT2INT16` macro that scales, clamps, and
+  rounds float samples to signed 16-bit values.
+
 ### `laplace.rs`
 - `ec_laplace_encode`, `ec_laplace_decode`, `ec_laplace_encode_p0`, and
   `ec_laplace_decode_p0` &rarr; port the Laplace probability model from

--- a/src/celt/float_cast.rs
+++ b/src/celt/float_cast.rs
@@ -1,0 +1,66 @@
+#![allow(dead_code)]
+
+//! Floating-point to integer conversion helpers from `celt/float_cast.h`.
+//!
+//! The original header provides a family of macros that round floating-point
+//! samples to integral types using the rounding behaviour guaranteed by C99's
+//! `lrintf()`/`lrint()` functions.  CELT relies on these helpers when bridging
+//! between the float API and the fixed-point internals.  The Rust port exposes
+//! equivalent functions so that other translated modules can depend on the same
+//! rounding semantics without reimplementing the details.
+
+use libm::rintf;
+
+/// Scaling factor used by CELT to map floating-point samples to its internal
+/// fixed-point representation.
+pub(crate) const CELT_SIG_SCALE: f32 = 32_768.0;
+
+/// Rounds a `f32` to the nearest `i32`, matching the behaviour of the
+/// `float2int()` helper from the C implementation.
+///
+/// The reference code delegates to `lrintf()` when it is available, which
+/// rounds to the nearest integer using the current floating-point rounding
+/// mode (round-to-nearest-even in practice).  Rust's `as` conversion from
+/// `f32` to `i32` already saturates on overflow, so the implementation simply
+/// applies `rintf()` before casting.
+#[must_use]
+pub(crate) fn float2int(value: f32) -> i32 {
+    rintf(value) as i32
+}
+
+/// Converts a floating-point sample to a signed 16-bit integer using CELT's
+/// canonical scaling and rounding behaviour.
+///
+/// Mirrors the `FLOAT2INT16()` macro in `float_cast.h` by scaling the input,
+/// clamping it to the representable range, and delegating to [`float2int`] for
+/// the final rounding step.
+#[must_use]
+pub(crate) fn float2int16(value: f32) -> i16 {
+    let scaled = (value * CELT_SIG_SCALE).clamp(-32_768.0, 32_767.0);
+    float2int(scaled) as i16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn float2int_rounds_to_nearest_even() {
+        // Half-way cases should round to the nearest even integer, matching the
+        // default IEEE 754 rounding mode used by the C implementation.
+        assert_eq!(float2int(1.5), 2);
+        assert_eq!(float2int(2.5), 2);
+        assert_eq!(float2int(-1.5), -2);
+        assert_eq!(float2int(-2.5), -2);
+    }
+
+    #[test]
+    fn float2int16_clamps_to_i16_range() {
+        // Values outside the 16-bit range are clamped before rounding.
+        assert_eq!(float2int16(2.0), 32_767);
+        assert_eq!(float2int16(-2.0), -32_768);
+        // In-range values follow the same rounding mode as float2int().
+        assert_eq!(float2int16(0.500_1 / CELT_SIG_SCALE), 1);
+        assert_eq!(float2int16(-0.500_1 / CELT_SIG_SCALE), -1);
+    }
+}

--- a/src/celt/math.rs
+++ b/src/celt/math.rs
@@ -11,10 +11,9 @@ use core::f32::consts::LN_2;
 use core::f32::consts::{LOG2_E, PI};
 
 use crate::celt::entcode::ec_ilog;
+use crate::celt::float_cast;
 use crate::celt::types::OpusInt32;
-use libm::{cosf, expf, logf, rintf, sqrtf};
-
-const CELT_SIG_SCALE: f32 = 32_768.0;
+use libm::{cosf, expf, logf, sqrtf};
 
 /// Integer square root mirroring `isqrt32()` from `celt/mathops.c`.
 ///
@@ -224,8 +223,7 @@ pub(crate) fn celt_float2int16(input: &[f32], output: &mut [i16]) {
     );
 
     for (dst, &sample) in output.iter_mut().zip(input.iter()) {
-        let scaled = (sample * CELT_SIG_SCALE).clamp(-32_768.0, 32_767.0);
-        *dst = rintf(scaled) as i16;
+        *dst = float_cast::float2int16(sample);
     }
 }
 
@@ -236,7 +234,8 @@ mod tests {
     use alloc::vec;
     use libm::cosf;
 
-    use super::{CELT_SIG_SCALE, isqrt32};
+    use super::isqrt32;
+    use crate::celt::float_cast::CELT_SIG_SCALE;
 
     use super::{
         celt_cos_norm, celt_div, celt_exp2, celt_float2int16, celt_ilog2, celt_log2, celt_maxabs16,

--- a/src/celt/mod.rs
+++ b/src/celt/mod.rs
@@ -12,6 +12,7 @@ mod cwrs;
 mod entcode;
 mod entdec;
 mod entenc;
+mod float_cast;
 mod kiss_fft;
 mod laplace;
 mod lpc;
@@ -40,6 +41,8 @@ pub(crate) use entcode::*;
 pub(crate) use entdec::*;
 #[allow(unused_imports)]
 pub(crate) use entenc::*;
+#[allow(unused_imports)]
+pub(crate) use float_cast::*;
 #[allow(unused_imports)]
 pub(crate) use kiss_fft::*;
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary
- port the lightweight float_cast helpers and expose CELT_SIG_SCALE, float2int, and float2int16 in Rust
- reuse the new helpers from the existing math conversions and document the port in PORTING_STATUS

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68e386c7b50c832a921329cf731317d3