### PR TITLE
Port quant_band_n1 helper from CELT bands

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -53,6 +53,12 @@ safely.
   number of quantisation levels used for the stereo angle, capping the
   resolution to guarantee that at least one pulse remains available for the side
   channel.
+- `BandCtx` and `BandCodingState` &rarr; provide the Rust equivalents of the
+  `struct band_ctx` bookkeeping and entropy coder dispatch used throughout
+  `celt/bands.c`.
+- `quant_band_n1` &rarr; ports the single-pulse PVQ special case from
+  `celt/bands.c`, coding a raw sign bit when only one coefficient is active and
+  resynthesising the unit vector for collapse prevention.
 - `spreading_decision` &rarr; ports the frame-level spreading classifier from
   `celt/bands.c`, building per-band histograms, smoothing the score, and
   applying the hysteresis used to stabilise PVQ spreading decisions while


### PR DESCRIPTION
## Summary
- add the `BandCtx` scaffolding and `BandCodingState` entropy wrapper needed by the CELT band quantiser
- port the `quant_band_n1` single-pulse PVQ helper and exercise it with an encode/decode round-trip test
- update the CELT porting status document with the new band context and helper coverage

## Testing
- cargo check
- cargo test


------
https://chatgpt.com/codex/tasks/task_b_68e38a7ac210832a993819516f43e2d9