### PR TITLE
Port compute_theta helper from bands.c

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -59,6 +59,9 @@ safely.
 - `quant_band_n1` &rarr; ports the single-pulse PVQ special case from
   `celt/bands.c`, coding a raw sign bit when only one coefficient is active and
   resynthesising the unit vector for collapse prevention.
+- `compute_theta` &rarr; ports the stereo/partition angle quantiser from
+  `celt/bands.c`, handling probability modelling, intensity detection, and fill
+  mask updates while accounting for the available fractional bit budget.
 - `spreading_decision` &rarr; ports the frame-level spreading classifier from
   `celt/bands.c`, building per-band histograms, smoothing the score, and
   applying the hysteresis used to stabilise PVQ spreading decisions while


### PR DESCRIPTION
## Summary
- port `compute_theta` from `celt/bands.c` along with the supporting `SplitCtx` bookkeeping and coder accessors in `BandCodingState`
- add an encode/decode round-trip unit test that exercises the new helper
- document the newly ported helper in `PORTING_STATUS.md`

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68e38f3fc274832a96889bbe9fccd4f2