### PR TITLE
Port quant_partition helper and document remaining bands work

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -8,6 +8,9 @@ safely.
 ## Rust code that already mirrors the C sources
 
 ### `bands.rs`
+- `quant_partition` &rarr; ports the recursive mono-partition helper from
+  `celt/bands.c` that splits bands when sufficient bits are available for
+  additional time/frequency resolution.
 - `hysteresis_decision` &rarr; ports the decision helper from `celt/bands.c`
   that keeps the spread classification stable when values hover near
   thresholds.
@@ -69,6 +72,13 @@ safely.
   `celt/bands.c`, building per-band histograms, smoothing the score, and
   applying the hysteresis used to stabilise PVQ spreading decisions while
   updating the high-frequency tapset selection heuristics.
+
+#### Remaining work
+
+- TODO: `quant_band`, `quant_band_stereo`, and `quant_all_bands` are still
+  pending. Translating them on top of `quant_partition` will require careful
+  handling of the lowband folding buffers and entropy coder snapshots, so they
+  should be tackled in follow-up changes to keep reviews manageable.
 
 ### `celt.rs`
 - `resampling_factor` &rarr; mirrors the sampling-rate-to-downsampling-factor


### PR DESCRIPTION
## Summary
- port the recursive `quant_partition` helper from `celt/bands.c`
- expose encoder/decoder accessors on `BandCodingState` to reuse the shared entropy coder
- update the CELT porting status to reflect the new helper and call out the remaining band quantiser work

## Testing
- cargo check
- cargo test
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_b_68e51224bcec832ab11564c7e7f77b63