### PR TITLE
Implement theta RDO path for CELT bands

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -73,8 +73,9 @@ safely.
   applying the hysteresis used to stabilise PVQ spreading decisions while
   updating the high-frequency tapset selection heuristics.
  - `quant_all_bands` &rarr; covers the top-level PVQ loop from `celt/bands.c`
-   that allocates per-band bit budgets, tracks folding state, and invokes the
-   mono/stereo band quantisers while updating the collapse masks.
+   that allocates per-band bit budgets, tracks folding state, evaluates the
+   two-pass theta RDO experiment, and invokes the mono/stereo band quantisers
+   while updating the collapse masks.
 
 ### `celt.rs`
 - `resampling_factor` &rarr; mirrors the sampling-rate-to-downsampling-factor


### PR DESCRIPTION
## Summary
- add an encoder snapshot helper in `entenc` and reuse it from the quantisation helpers
- implement the theta RDO branch in `quant_all_bands` using the shared snapshot API
- update the porting status to note that the RDO logic is now translated

## Testing
- cargo check
- cargo test
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_b_68e54681fffc832a9294a7f2637b9c19