### PR TITLE
Add CELT decoder allocation scaffolding

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -93,6 +93,21 @@ safely.
   exposing the library identifier used by applications to detect build
   variants.
 
+### `celt_decoder.rs`
+- `CeltDecoderAlloc` &rarr; owns the trailing decoder buffers (`decode_mem`, LPC
+  history, and band energy arrays) that follow `CELTDecoder` in the C layout,
+  allocating them with Rust `Vec`s and exposing a safe `as_decoder()` helper to
+  obtain an `OpusCustomDecoder` view.
+- `LPC_ORDER` &rarr; surfaces the decoder-side LPC history length so future
+  ports of the PLC and post-filter routines share the same constant as the
+  reference implementation.
+- `size_in_bytes`/`reset` &rarr; utility helpers mirroring the allocation sizing
+  and zeroing performed by the reference implementation when creating and
+  reinitialising decoder states.
+- TODO: Port the frame decode path (`celt_decode_with_ec()`), packet-loss
+  concealment, and post-filter helpers while reusing the allocation scaffolding
+  introduced here.
+
 ### `math.rs`
 - `fast_atan2f` &rarr; mirrors the helper of the same name in
   `celt/mathops.h`.

--- a/src/celt/celt_decoder.rs
+++ b/src/celt/celt_decoder.rs
@@ -1,0 +1,185 @@
+#![allow(dead_code)]
+
+//! Decoder scaffolding ported from `celt/celt_decoder.c`.
+//!
+//! The reference implementation combines the primary decoder state with a
+//! trailing buffer that stores the pitch predictor history, LPC coefficients,
+//! and band energy memories.  This module mirrors the allocation strategy so
+//! that higher level decode routines can be ported gradually while continuing
+//! to rely on the Rust ownership model for safety.
+//!
+//! Only the allocation helpers are provided for now.  The full decoding loop,
+//! packet loss concealment, and post-filter plumbing still live in the C
+//! sources and will be translated in follow-up patches.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::celt::types::{CeltGlog, CeltSig, OpusCustomDecoder, OpusCustomMode, OpusVal16};
+
+/// Linear prediction order used by the decoder side filters.
+///
+/// Mirrors the `LPC_ORDER` constant from the reference implementation.  The
+/// value is surfaced here so future ports that rely on the LPC history length
+/// can share the same constant.
+const LPC_ORDER: usize = 24;
+
+/// Helper owning the trailing buffers that back [`OpusCustomDecoder`].
+///
+/// The C implementation allocates the decoder struct followed by a number of
+/// variable-length arrays.  Keeping the storage separate in Rust avoids unsafe
+/// pointer arithmetic and simplifies sharing the buffers across temporary
+/// decoder views used during reset or PLC.
+#[derive(Debug, Default)]
+pub(crate) struct CeltDecoderAlloc {
+    decode_mem: Vec<CeltSig>,
+    lpc: Vec<OpusVal16>,
+    old_ebands: Vec<CeltGlog>,
+    old_log_e: Vec<CeltGlog>,
+    old_log_e2: Vec<CeltGlog>,
+    background_log_e: Vec<CeltGlog>,
+}
+
+impl CeltDecoderAlloc {
+    /// Creates a new allocation suitable for the provided mode and channel
+    /// configuration.
+    ///
+    /// The decoder requires per-channel history buffers for the overlap region
+    /// as well as twice the number of energy bands tracked by the mode.  The
+    /// allocations follow the layout of the C implementation while leveraging
+    /// Rust's `Vec` to manage the backing storage.
+    pub(crate) fn new(mode: &OpusCustomMode<'_>, channels: usize) -> Self {
+        assert!(channels > 0, "decoder must contain at least one channel");
+
+        let overlap = mode.overlap * channels;
+        let lpc = LPC_ORDER * channels;
+        let band_count = 2 * mode.num_ebands;
+
+        Self {
+            decode_mem: vec![0.0; overlap],
+            lpc: vec![0.0; lpc],
+            old_ebands: vec![0.0; band_count],
+            old_log_e: vec![0.0; band_count],
+            old_log_e2: vec![0.0; band_count],
+            background_log_e: vec![0.0; band_count],
+        }
+    }
+
+    /// Returns the total size in bytes consumed by the allocation.
+    ///
+    /// Mirrors the behaviour of `celt_decoder_get_size()` in spirit by exposing
+    /// how much storage is required for the decoder and its trailing buffers.
+    /// The actual C helper only depends on the channel count; we include the
+    /// mode so the calculation reflects the precise band layout in use.  A
+    /// follow-up port of the fixed allocation used by the reference
+    /// implementation will replace this helper with a fully bit-exact
+    /// translation.
+    pub(crate) fn size_in_bytes(&self) -> usize {
+        self.decode_mem.len() * core::mem::size_of::<CeltSig>()
+            + self.lpc.len() * core::mem::size_of::<OpusVal16>()
+            + (self.old_ebands.len()
+                + self.old_log_e.len()
+                + self.old_log_e2.len()
+                + self.background_log_e.len())
+                * core::mem::size_of::<CeltGlog>()
+    }
+
+    /// Borrows the allocation as an [`OpusCustomDecoder`] tied to the provided
+    /// mode.
+    ///
+    /// Each call returns a fresh decoder view referencing the same backing
+    /// buffers.  This mirrors the C layout where the state and trailing memory
+    /// occupy a single blob, enabling the caller to reset or reuse the decoder
+    /// without reallocating.
+    pub(crate) fn as_decoder<'a>(
+        &'a mut self,
+        mode: &'a OpusCustomMode<'a>,
+        channels: usize,
+        stream_channels: usize,
+    ) -> OpusCustomDecoder<'a> {
+        OpusCustomDecoder::new(
+            mode,
+            channels,
+            stream_channels,
+            self.decode_mem.as_mut_slice(),
+            self.lpc.as_mut_slice(),
+            self.old_ebands.as_mut_slice(),
+            self.old_log_e.as_mut_slice(),
+            self.old_log_e2.as_mut_slice(),
+            self.background_log_e.as_mut_slice(),
+        )
+    }
+
+    /// Resets the allocation contents to zero.
+    pub(crate) fn reset(&mut self) {
+        for sample in &mut self.decode_mem {
+            *sample = 0.0;
+        }
+        for coeff in &mut self.lpc {
+            *coeff = 0.0;
+        }
+        for history in &mut self.old_ebands {
+            *history = 0.0;
+        }
+        for history in &mut self.old_log_e {
+            *history = 0.0;
+        }
+        for history in &mut self.old_log_e2 {
+            *history = 0.0;
+        }
+        for history in &mut self.background_log_e {
+            *history = 0.0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CeltDecoderAlloc, LPC_ORDER};
+    use crate::celt::types::{MdctLookup, OpusCustomMode, PulseCacheData};
+    use alloc::vec;
+
+    #[test]
+    fn allocates_expected_band_buffers() {
+        let e_bands = [0, 2, 5];
+        let alloc_vectors = [0u8; 4];
+        let log_n = [0i16; 2];
+        let window = [0.0f32; 4];
+        let mdct = MdctLookup::new(8, 0);
+        let cache = PulseCacheData::new(vec![0; 6], vec![0; 6], vec![0; 6]);
+        let mode = OpusCustomMode::new(
+            48_000,
+            4,
+            &e_bands,
+            &alloc_vectors,
+            &log_n,
+            &window,
+            mdct,
+            cache,
+        );
+
+        let mut alloc = CeltDecoderAlloc::new(&mode, 2);
+        assert_eq!(alloc.decode_mem.len(), mode.overlap * 2);
+        assert_eq!(alloc.lpc.len(), LPC_ORDER * 2);
+        assert_eq!(alloc.old_ebands.len(), 2 * mode.num_ebands);
+        assert_eq!(alloc.old_log_e.len(), 2 * mode.num_ebands);
+        assert_eq!(alloc.old_log_e2.len(), 2 * mode.num_ebands);
+        assert_eq!(alloc.background_log_e.len(), 2 * mode.num_ebands);
+
+        // Ensure the reset helper clears all buffers.
+        alloc.decode_mem.fill(1.0);
+        alloc.lpc.fill(1.0);
+        alloc.old_ebands.fill(1.0);
+        alloc.old_log_e.fill(1.0);
+        alloc.old_log_e2.fill(1.0);
+        alloc.background_log_e.fill(1.0);
+        alloc.reset();
+
+        assert!(alloc.decode_mem.iter().all(|&v| v == 0.0));
+        assert!(alloc.lpc.iter().all(|&v| v == 0.0));
+        assert!(alloc.old_ebands.iter().all(|&v| v == 0.0));
+        assert!(alloc.old_log_e.iter().all(|&v| v == 0.0));
+        assert!(alloc.old_log_e2.iter().all(|&v| v == 0.0));
+        assert!(alloc.background_log_e.iter().all(|&v| v == 0.0));
+    }
+}

--- a/src/celt/mod.rs
+++ b/src/celt/mod.rs
@@ -8,6 +8,7 @@
 mod bands;
 #[allow(clippy::module_inception)]
 mod celt;
+mod celt_decoder;
 mod cpu_support;
 mod cwrs;
 mod entcode;
@@ -32,6 +33,8 @@ mod vq;
 pub(crate) use bands::*;
 #[allow(unused_imports)]
 pub(crate) use celt::*;
+#[allow(unused_imports)]
+pub(crate) use celt_decoder::*;
 #[allow(unused_imports)]
 pub(crate) use cpu_support::*;
 #[allow(unused_imports)]

--- a/src/celt/rate.rs
+++ b/src/celt/rate.rs
@@ -437,9 +437,10 @@ pub(crate) fn interp_bits2pulses(
                     skip = true;
                 }
             } else if let Some(dec) = decoder.as_deref_mut()
-                && dec.dec_bit_logp(1) != 0 {
-                    skip = true;
-                }
+                && dec.dec_bit_logp(1) != 0
+            {
+                skip = true;
+            }
 
             if skip {
                 break;
@@ -568,8 +569,10 @@ pub(crate) fn interp_bits2pulses(
             ebits[band] = eb;
 
             if excess > 0 {
-                let extra_fine =
-                    min(excess >> (stereo_shift + BITRES), MAX_FINE_BITS - ebits[band]);
+                let extra_fine = min(
+                    excess >> (stereo_shift + BITRES),
+                    MAX_FINE_BITS - ebits[band],
+                );
                 ebits[band] += extra_fine;
                 let extra_bits = (extra_fine * channels) << BITRES;
                 if extra_bits >= excess - local_balance {
@@ -663,7 +666,8 @@ pub(crate) fn clt_compute_allocation(
             * n
             * (alloc_trim - 5 - lm)
             * OpusInt32::try_from(end - j - 1).unwrap()
-            * (1 << split_shift)) >> 6;
+            * (1 << split_shift))
+            >> 6;
         if (n << lm) == 1 {
             trim_offset[j] -= channels << BITRES;
         }

--- a/src/celt/types.rs
+++ b/src/celt/types.rs
@@ -55,7 +55,10 @@ impl MdctLookup {
         let mut inverse = Vec::with_capacity(max_shift + 1);
         for shift in 0..=max_shift {
             let n = len >> shift;
-            assert!(n.is_multiple_of(4), "MDCT length must be a multiple of four");
+            assert!(
+                n.is_multiple_of(4),
+                "MDCT length must be a multiple of four"
+            );
             forward.push(MiniKissFft::new(n >> 2, false));
             inverse.push(MiniKissFft::new(n >> 2, true));
         }

--- a/src/silk/decoder.rs
+++ b/src/silk/decoder.rs
@@ -887,11 +887,7 @@ impl Decoder {
         let mut res_lag = [0.0f32; MAX_RES_LAG];
 
         let res_len = excitation.len.min(res.len());
-        for (dst, &value) in res
-            .iter_mut()
-            .zip(excitation.values.iter())
-            .take(res_len)
-        {
+        for (dst, &value) in res.iter_mut().zip(excitation.values.iter()).take(res_len) {
             *dst = (value as f32) * INV_Q23;
         }
 


### PR DESCRIPTION
## Summary
- add a `celt_decoder` module that owns the trailing decoder buffers and exposes a safe view
- surface the decoder LPC order and update the porting status with the new scaffolding
- keep module exports in sync and document the remaining TODO for the decode path

## Testing
- cargo fmt
- cargo check
- cargo test
- cargo clippy


------
https://chatgpt.com/codex/tasks/task_b_68e621cea1b0832a82a3c32cc0aa7089