### PR TITLE
Expand CELT decoder buffer scaffolding

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -98,6 +98,9 @@ safely.
   history, and band energy arrays) that follow `CELTDecoder` in the C layout,
   allocating them with Rust `Vec`s and exposing a safe `as_decoder()` helper to
   obtain an `OpusCustomDecoder` view.
+- `DECODE_BUFFER_SIZE` &rarr; mirrors the two-kilobyte circular history kept per
+  channel by `celt_decoder.c`, allowing future PLC and post-filter ports to rely
+  on an accurate backing buffer size.
 - `LPC_ORDER` &rarr; surfaces the decoder-side LPC history length so future
   ports of the PLC and post-filter routines share the same constant as the
   reference implementation.
@@ -107,9 +110,11 @@ safely.
 - `init_decoder` &rarr; validates the channel layout, configures architecture
   selection, and initialises the runtime fields exposed by `OpusCustomDecoder`
   while mirroring the zeroing behaviour of `opus_custom_decoder_init()`.
-- TODO: Port the frame decode path (`celt_decode_with_ec()`), packet-loss
-  concealment, and post-filter helpers while reusing the allocation scaffolding
-  introduced here.
+- TODO: Port the frame header parsing and allocation logic that feed
+  `celt_decode_with_ec()`, including the range decoder setup and bit allocation
+  bookkeeping.
+- TODO: Translate the remaining frame synthesis path, PLC, and post-filter
+  helpers once the header parsing scaffolding is in place.
 
 ### `math.rs`
 - `fast_atan2f` &rarr; mirrors the helper of the same name in

--- a/src/celt/types.rs
+++ b/src/celt/types.rs
@@ -436,8 +436,14 @@ impl<'a> OpusCustomDecoder<'a> {
         old_log_e2: &'a mut [CeltGlog],
         background_log_e: &'a mut [CeltGlog],
     ) -> Self {
-        let overlap = mode.overlap * channels;
-        debug_assert!(decode_mem.len() >= overlap);
+        let overlap = mode.overlap;
+        let decode_stride = if channels > 0 {
+            decode_mem.len() / channels
+        } else {
+            0
+        };
+        debug_assert!(channels == 0 || decode_stride * channels == decode_mem.len());
+        debug_assert!(decode_stride >= overlap);
         let band_count = 2 * mode.num_ebands;
         debug_assert_eq!(old_ebands.len(), band_count);
         debug_assert_eq!(old_log_e.len(), band_count);


### PR DESCRIPTION
## Summary
- mirror the CELT decoder's per-channel history size by introducing `DECODE_BUFFER_SIZE` and resizing the backing allocation
- tighten the custom decoder constructor checks so per-channel strides match the new layout
- document the updated buffer scaffolding and split the remaining decoder TODOs in the porting guide

## Testing
- cargo check
- cargo test
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_b_68e62b478360832a9ffb52385a65d2fc