### PR TITLE
Port validate_celt_decoder checks

### DIFF
--- a/src/celt/PORTING_STATUS.md
+++ b/src/celt/PORTING_STATUS.md
@@ -120,9 +120,12 @@ safely.
   &rarr; translate the frame-header parsing and bit-allocation bookkeeping that
   feed `celt_decode_with_ec()`, including range-decoder setup, dynamic
   allocation boosts, TF selection, and the post-filter parameter decoding.
+- `validate_celt_decoder` &rarr; mirrors the debug-time sanity checks from
+  `celt/celt_decoder.c`, ensuring the decoder state remains internally
+  consistent before the synthesis path is executed.
 - **Still to port:** the synthesis side is largely unimplemented. The C
-  routines `validate_celt_decoder()`, `celt_decoder_get_size()`,
-  `opus_custom_decoder_get_size()`, `celt_decoder_init()`, and the public
+  routines `celt_decoder_get_size()`, `opus_custom_decoder_get_size()`,
+  `celt_decoder_init()`, and the public
   wrappers such as `opus_custom_decode()`/`opus_custom_decode_float()` remain to
   be mirrored so the allocation matches the reference layout exactly. The
   signal reconstruction helpers (`deemphasis[_stereo]_simple()`,

--- a/src/celt/celt.rs
+++ b/src/celt/celt.rs
@@ -10,7 +10,7 @@
 use crate::celt::types::{CeltCoef, OpusCustomMode, OpusInt32, OpusVal16, OpusVal32};
 
 /// Minimum comb-filter period supported by the scalar implementation.
-const COMBFILTER_MINPERIOD: usize = 15;
+pub(crate) const COMBFILTER_MINPERIOD: usize = 15;
 
 /// Tapset gains mirroring the tables embedded in the reference implementation.
 const TAPSET_GAINS: [[OpusVal16; 3]; 3] = [


### PR DESCRIPTION
## Summary
- expose the comb-filter minimum period so decoder utilities can share it
- port the `validate_celt_decoder` helper, adding PLC pitch constants and unit tests
- refresh the CELT porting guide to record the newly translated routine

## Testing
- cargo check
- cargo test
- cargo clippy

------
https://chatgpt.com/codex/tasks/task_b_68e6858bcc30832aa90507d1d2e167ba